### PR TITLE
Implement master profile features

### DIFF
--- a/smelite_app/smelite_app/Controllers/MasterController.cs
+++ b/smelite_app/smelite_app/Controllers/MasterController.cs
@@ -1,24 +1,88 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using smelite_app.Models;
+using smelite_app.Services;
 
 namespace smelite_app.Controllers
 {
     [Authorize(Roles = "Master")]
     public class MasterController : Controller
     {
-        public IActionResult Profile()
+        private readonly IMasterService _masterService;
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public MasterController(IMasterService masterService, UserManager<ApplicationUser> userManager)
         {
-            return View();
+            _masterService = masterService;
+            _userManager = userManager;
         }
 
+        public async Task<IActionResult> Profile()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+                return NotFound();
+
+            var profile = await _masterService.GetByUserIdAsync(user.Id);
+            return View(profile);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Edit()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) return NotFound();
+
+            var profile = await _masterService.GetByUserIdAsync(user.Id);
+            return View(profile);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Edit(MasterProfile model)
+        {
+            if (!ModelState.IsValid) return View(model);
+            await _masterService.UpdateProfileAsync(model);
+            return RedirectToAction(nameof(Profile));
+        }
+
+        [HttpGet]
         public IActionResult CreateCraft()
         {
             return View();
         }
 
-        public IActionResult Sessions()
+        [HttpPost]
+        public async Task<IActionResult> CreateCraft(Craft craft)
         {
-            return View();
+            if (!ModelState.IsValid) return View(craft);
+
+            var user = await _userManager.GetUserAsync(User);
+            var profile = await _masterService.GetByUserIdAsync(user!.Id);
+            if (profile == null) return NotFound();
+
+            await _masterService.AddCraftAsync(profile.Id, craft);
+            return RedirectToAction(nameof(Crafts));
+        }
+
+        public async Task<IActionResult> Crafts()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            var profile = await _masterService.GetByUserIdAsync(user!.Id);
+            if (profile == null) return NotFound();
+
+            var crafts = await _masterService.GetCraftsAsync(profile.Id);
+            return View(crafts);
+        }
+
+        public async Task<IActionResult> Sessions()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            var profile = await _masterService.GetByUserIdAsync(user!.Id);
+            if (profile == null) return NotFound();
+
+            var apps = await _masterService.GetApprenticeshipsAsync(profile.Id);
+            return View(apps);
         }
     }
 }

--- a/smelite_app/smelite_app/Repositories/IMasterRepository.cs
+++ b/smelite_app/smelite_app/Repositories/IMasterRepository.cs
@@ -5,5 +5,13 @@ namespace smelite_app.Repositories
     public interface IMasterRepository
     {
         Task AddProfileAsync(MasterProfile profile);
+
+        Task<MasterProfile?> GetByUserIdAsync(string userId);
+        Task UpdateProfileAsync(MasterProfile profile);
+
+        Task AddCraftAsync(int masterProfileId, Craft craft);
+        Task<List<Craft>> GetCraftsAsync(int masterProfileId);
+
+        Task<List<Apprenticeship>> GetApprenticeshipsAsync(int masterProfileId);
     }
 }

--- a/smelite_app/smelite_app/Repositories/MasterRepository.cs
+++ b/smelite_app/smelite_app/Repositories/MasterRepository.cs
@@ -1,4 +1,5 @@
-﻿using smelite_app.Data;
+﻿using Microsoft.EntityFrameworkCore;
+using smelite_app.Data;
 using smelite_app.Models;
 
 namespace smelite_app.Repositories
@@ -14,6 +15,57 @@ namespace smelite_app.Repositories
         {
             _context.MasterProfiles.Add(profile);
             await _context.SaveChangesAsync();
+        }
+
+        public Task<MasterProfile?> GetByUserIdAsync(string userId)
+        {
+            return _context.MasterProfiles
+                .Include(mp => mp.ApplicationUser)
+                .Include(mp => mp.MasterProfileCrafts)
+                    .ThenInclude(mpc => mpc.Craft)
+                .Include(mp => mp.Tasks)
+                    .ThenInclude(t => t.ApprenticeProfile)
+                        .ThenInclude(ap => ap.ApplicationUser)
+                .FirstOrDefaultAsync(mp => mp.ApplicationUserId == userId);
+        }
+
+        public async Task UpdateProfileAsync(MasterProfile profile)
+        {
+            _context.MasterProfiles.Update(profile);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task AddCraftAsync(int masterProfileId, Craft craft)
+        {
+            _context.Crafts.Add(craft);
+            await _context.SaveChangesAsync();
+
+            _context.MasterProfileCrafts.Add(new MasterProfileCraft
+            {
+                MasterProfileId = masterProfileId,
+                CraftId = craft.Id
+            });
+            await _context.SaveChangesAsync();
+        }
+
+        public Task<List<Craft>> GetCraftsAsync(int masterProfileId)
+        {
+            return _context.MasterProfileCrafts
+                .Where(mpc => mpc.MasterProfileId == masterProfileId)
+                .Select(mpc => mpc.Craft)
+                .Include(c => c.CraftType)
+                .ToListAsync();
+        }
+
+        public Task<List<Apprenticeship>> GetApprenticeshipsAsync(int masterProfileId)
+        {
+            return _context.Apprenticeships
+                .Include(a => a.ApprenticeProfile)
+                    .ThenInclude(ap => ap.ApplicationUser)
+                .Include(a => a.CraftOffering)
+                    .ThenInclude(o => o.Craft)
+                .Where(a => a.MasterProfileId == masterProfileId)
+                .ToListAsync();
         }
     }
 }

--- a/smelite_app/smelite_app/Services/IMasterService.cs
+++ b/smelite_app/smelite_app/Services/IMasterService.cs
@@ -8,5 +8,11 @@ namespace smelite_app.Services
         Task<MasterProfile?> GetByIdAsync(int id);
         Task<List<CraftType>> GetCraftTypesAsync();
         Task<List<CraftLocation>> GetLocationsAsync();
+
+        Task<MasterProfile?> GetByUserIdAsync(string userId);
+        Task UpdateProfileAsync(MasterProfile profile);
+        Task AddCraftAsync(int masterProfileId, Craft craft);
+        Task<List<Craft>> GetCraftsAsync(int masterProfileId);
+        Task<List<Apprenticeship>> GetApprenticeshipsAsync(int masterProfileId);
     }
 }

--- a/smelite_app/smelite_app/Services/MasterService.cs
+++ b/smelite_app/smelite_app/Services/MasterService.cs
@@ -8,11 +8,13 @@ namespace smelite_app.Services
     public class MasterService : IMasterService
     {
         private readonly ICraftRepository _repository;
+        private readonly IMasterRepository _masterRepository;
         private readonly ApplicationDbContext _context;
 
-        public MasterService(ICraftRepository repository, ApplicationDbContext context)
+        public MasterService(ICraftRepository repository, IMasterRepository masterRepository, ApplicationDbContext context)
         {
             _repository = repository;
+            _masterRepository = masterRepository;
             _context = context;
         }
 
@@ -51,6 +53,31 @@ namespace smelite_app.Services
         public Task<List<CraftLocation>> GetLocationsAsync()
         {
             return _context.CraftLocations.ToListAsync();
+        }
+
+        public Task<MasterProfile?> GetByUserIdAsync(string userId)
+        {
+            return _masterRepository.GetByUserIdAsync(userId);
+        }
+
+        public Task UpdateProfileAsync(MasterProfile profile)
+        {
+            return _masterRepository.UpdateProfileAsync(profile);
+        }
+
+        public Task AddCraftAsync(int masterProfileId, Craft craft)
+        {
+            return _masterRepository.AddCraftAsync(masterProfileId, craft);
+        }
+
+        public Task<List<Craft>> GetCraftsAsync(int masterProfileId)
+        {
+            return _masterRepository.GetCraftsAsync(masterProfileId);
+        }
+
+        public Task<List<Apprenticeship>> GetApprenticeshipsAsync(int masterProfileId)
+        {
+            return _masterRepository.GetApprenticeshipsAsync(masterProfileId);
         }
     }
 }

--- a/smelite_app/smelite_app/Views/Master/Crafts.cshtml
+++ b/smelite_app/smelite_app/Views/Master/Crafts.cshtml
@@ -1,0 +1,9 @@
+@model IEnumerable<smelite_app.Models.Craft>
+
+<h2>Your Crafts</h2>
+<ul>
+@foreach (var c in Model)
+{
+    <li>@c.Name (@c.CraftType?.Name)</li>
+}
+</ul>

--- a/smelite_app/smelite_app/Views/Master/CreateCraft.cshtml
+++ b/smelite_app/smelite_app/Views/Master/CreateCraft.cshtml
@@ -1,1 +1,19 @@
+@model smelite_app.Models.Craft
+
 <h2>Create Craft</h2>
+
+<form asp-action="CreateCraft" method="post">
+    <div>
+        <label asp-for="Name"></label>
+        <input asp-for="Name" />
+    </div>
+    <div>
+        <label asp-for="CraftDescription"></label>
+        <textarea asp-for="CraftDescription"></textarea>
+    </div>
+    <div>
+        <label asp-for="ExperienceYears"></label>
+        <input asp-for="ExperienceYears" type="number" />
+    </div>
+    <button type="submit">Create</button>
+</form>

--- a/smelite_app/smelite_app/Views/Master/Edit.cshtml
+++ b/smelite_app/smelite_app/Views/Master/Edit.cshtml
@@ -1,0 +1,11 @@
+@model smelite_app.Models.MasterProfile
+
+<h2>Edit Profile</h2>
+
+<form asp-action="Edit" method="post">
+    <div>
+        <label asp-for="PersonalInformation"></label>
+        <textarea asp-for="PersonalInformation"></textarea>
+    </div>
+    <button type="submit">Save</button>
+</form>

--- a/smelite_app/smelite_app/Views/Master/Profile.cshtml
+++ b/smelite_app/smelite_app/Views/Master/Profile.cshtml
@@ -1,1 +1,9 @@
+@model smelite_app.Models.MasterProfile
+
 <h2>Master Profile</h2>
+
+<p>Name: @Model.ApplicationUser.FirstName @Model.ApplicationUser.LastName</p>
+<p>Email: @Model.ApplicationUser.Email</p>
+<p>Info: @Model.PersonalInformation</p>
+
+<a asp-action="Edit">Edit details</a>

--- a/smelite_app/smelite_app/Views/Master/Sessions.cshtml
+++ b/smelite_app/smelite_app/Views/Master/Sessions.cshtml
@@ -1,1 +1,10 @@
-<h2>Master Sessions</h2>
+@model IEnumerable<smelite_app.Models.Apprenticeship>
+
+<h2>Apprenticeships</h2>
+
+<ul>
+@foreach (var a in Model)
+{
+    <li>@a.ApprenticeProfile.ApplicationUser.FirstName @a.ApprenticeProfile.ApplicationUser.LastName - @a.CraftOffering.Craft.Name - @a.Status</li>
+}
+</ul>


### PR DESCRIPTION
## Summary
- extend repository to fetch/edit master profiles and related data
- add service methods for master profile CRUD and craft management
- update master controller to expose profile, edit, craft and session actions
- add simple Razor views for profile editing, craft creation, craft listing and sessions

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b45788888330bf524bdbb9bc0846