### PR TITLE
Enable custom craft offerings

### DIFF
--- a/smelite_app/smelite_app/Controllers/MasterController.cs
+++ b/smelite_app/smelite_app/Controllers/MasterController.cs
@@ -132,13 +132,9 @@ namespace smelite_app.Controllers
         public async Task<IActionResult> CreateCraft()
         {
             var types = await _craftService.GetCraftTypesAsync();
-            var locations = await _craftService.GetLocationsAsync();
-            var packages = await _craftService.GetPackagesAsync();
             var vm = new CraftViewModel
             {
                 CraftTypes = new SelectList(types, "Id", "Name"),
-                Locations = new SelectList(locations, "Id", "Name"),
-                Packages = new SelectList(packages, "Id", "SessionsCount"),
                 Offerings = new List<CraftOfferingFormViewModel> { new CraftOfferingFormViewModel() }
             };
             return View(vm);
@@ -150,8 +146,6 @@ namespace smelite_app.Controllers
             if (!ModelState.IsValid)
             {
                 craft.CraftTypes = new SelectList(await _craftService.GetCraftTypesAsync(), "Id", "Name");
-                craft.Locations = new SelectList(await _craftService.GetLocationsAsync(), "Id", "Name");
-                craft.Packages = new SelectList(await _craftService.GetPackagesAsync(), "Id", "SessionsCount");
                 return View(craft);
             }
 
@@ -168,8 +162,8 @@ namespace smelite_app.Controllers
             };
             var offerings = craft.Offerings.Select(o => new CraftOffering
             {
-                CraftLocationId = o.CraftLocationId,
-                CraftPackageId = o.CraftPackageId,
+                CraftLocation = new CraftLocation { Name = o.LocationName },
+                CraftPackage = new CraftPackage { SessionsCount = o.SessionsCount, Label = o.PackageLabel },
                 Price = o.Price
             }).ToList();
 
@@ -199,8 +193,6 @@ namespace smelite_app.Controllers
                 return NotFound();
 
             var types = await _craftService.GetCraftTypesAsync();
-            var locations = await _craftService.GetLocationsAsync();
-            var packages = await _craftService.GetPackagesAsync();
             var vm = new EditCraftViewModel
             {
                 Id = craft.Id,
@@ -209,12 +201,11 @@ namespace smelite_app.Controllers
                 ExperienceYears = craft.ExperienceYears,
                 CraftTypeId = craft.CraftTypeId,
                 CraftTypes = new SelectList(types, "Id", "Name", craft.CraftTypeId),
-                Locations = new SelectList(locations, "Id", "Name"),
-                Packages = new SelectList(packages, "Id", "SessionsCount"),
                 Offerings = craft.CraftOfferings.Select(o => new CraftOfferingFormViewModel
                 {
-                    CraftLocationId = o.CraftLocationId,
-                    CraftPackageId = o.CraftPackageId,
+                    LocationName = o.CraftLocation.Name,
+                    SessionsCount = o.CraftPackage.SessionsCount,
+                    PackageLabel = o.CraftPackage.Label,
                     Price = o.Price
                 }).ToList()
             };
@@ -227,8 +218,6 @@ namespace smelite_app.Controllers
             if (!ModelState.IsValid)
             {
                 model.CraftTypes = new SelectList(await _craftService.GetCraftTypesAsync(), "Id", "Name", model.CraftTypeId);
-                model.Locations = new SelectList(await _craftService.GetLocationsAsync(), "Id", "Name");
-                model.Packages = new SelectList(await _craftService.GetPackagesAsync(), "Id", "SessionsCount");
                 return View(model);
             }
 
@@ -247,8 +236,8 @@ namespace smelite_app.Controllers
 
             var offerings = model.Offerings.Select(o => new CraftOffering
             {
-                CraftLocationId = o.CraftLocationId,
-                CraftPackageId = o.CraftPackageId,
+                CraftLocation = new CraftLocation { Name = o.LocationName },
+                CraftPackage = new CraftPackage { SessionsCount = o.SessionsCount, Label = o.PackageLabel },
                 Price = o.Price
             }).ToList();
 

--- a/smelite_app/smelite_app/ViewModels/Craft/CraftOfferingFormViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Craft/CraftOfferingFormViewModel.cs
@@ -5,12 +5,18 @@ namespace smelite_app.ViewModels.Master
     public class CraftOfferingFormViewModel
     {
         [Required]
+        [MaxLength(300)]
         [Display(Name = "Location")]
-        public int CraftLocationId { get; set; }
+        public string LocationName { get; set; } = string.Empty;
 
         [Required]
-        [Display(Name = "Package")]
-        public int CraftPackageId { get; set; }
+        [Range(0, 20)]
+        [Display(Name = "Sessions")]
+        public int SessionsCount { get; set; }
+
+        [MaxLength(100)]
+        [Display(Name = "Package Label")]
+        public string? PackageLabel { get; set; }
 
         [Required]
         [Range(0, 100000)]

--- a/smelite_app/smelite_app/ViewModels/Craft/CraftViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Craft/CraftViewModel.cs
@@ -21,10 +21,6 @@ namespace smelite_app.ViewModels.Master
 
         public SelectList? CraftTypes { get; set; }
 
-        public SelectList? Locations { get; set; }
-
-        public SelectList? Packages { get; set; }
-
         public List<CraftOfferingFormViewModel> Offerings { get; set; } = new();
     }
 }

--- a/smelite_app/smelite_app/Views/Master/CreateCraft.cshtml
+++ b/smelite_app/smelite_app/Views/Master/CreateCraft.cshtml
@@ -25,13 +25,10 @@
         @for (int i = 0; i < Model.Offerings.Count; i++)
         {
             <div class="offering border p-2 mb-2">
-                <select asp-for="Offerings[i].CraftLocationId" asp-items="Model.Locations">
-                    <option value="">Location</option>
-                </select>
-                <select asp-for="Offerings[i].CraftPackageId" asp-items="Model.Packages">
-                    <option value="">Package</option>
-                </select>
-                <input asp-for="Offerings[i].Price" placeholder="Price" />
+                <input asp-for="Offerings[i].LocationName" placeholder="Location" class="form-control mb-1" />
+                <input asp-for="Offerings[i].SessionsCount" type="number" min="0" max="20" placeholder="Sessions" class="form-control mb-1" />
+                <input asp-for="Offerings[i].PackageLabel" placeholder="Label" class="form-control mb-1" />
+                <input asp-for="Offerings[i].Price" placeholder="Price" class="form-control" />
             </div>
         }
     </div>
@@ -43,11 +40,10 @@
     <script>
         $("#add-offer").on("click", function () {
             var index = $("#offerings .offering").length;
-            var locOptions = $("select[name='Offerings[0].CraftLocationId']").html();
-            var packOptions = $("select[name='Offerings[0].CraftPackageId']").html();
             var template = `<div class='offering border p-2 mb-2'>` +
-                `<select name='Offerings[${index}].CraftLocationId' class='form-control'>` + locOptions + `</select>` +
-                `<select name='Offerings[${index}].CraftPackageId' class='form-control'>` + packOptions + `</select>` +
+                `<input name='Offerings[${index}].LocationName' class='form-control mb-1' placeholder='Location' />` +
+                `<input name='Offerings[${index}].SessionsCount' type='number' min='0' max='20' class='form-control mb-1' placeholder='Sessions' />` +
+                `<input name='Offerings[${index}].PackageLabel' class='form-control mb-1' placeholder='Label' />` +
                 `<input name='Offerings[${index}].Price' class='form-control' placeholder='Price' />` +
                 `</div>`;
             $("#offerings").append(template);

--- a/smelite_app/smelite_app/Views/Master/EditCraft.cshtml
+++ b/smelite_app/smelite_app/Views/Master/EditCraft.cshtml
@@ -26,13 +26,10 @@
         @for (int i = 0; i < Model.Offerings.Count; i++)
         {
             <div class="offering border p-2 mb-2">
-                <select asp-for="Offerings[i].CraftLocationId" asp-items="Model.Locations">
-                    <option value="">Location</option>
-                </select>
-                <select asp-for="Offerings[i].CraftPackageId" asp-items="Model.Packages">
-                    <option value="">Package</option>
-                </select>
-                <input asp-for="Offerings[i].Price" placeholder="Price" />
+                <input asp-for="Offerings[i].LocationName" placeholder="Location" class="form-control mb-1" />
+                <input asp-for="Offerings[i].SessionsCount" type="number" min="0" max="20" placeholder="Sessions" class="form-control mb-1" />
+                <input asp-for="Offerings[i].PackageLabel" placeholder="Label" class="form-control mb-1" />
+                <input asp-for="Offerings[i].Price" placeholder="Price" class="form-control" />
             </div>
         }
     </div>
@@ -44,11 +41,10 @@
     <script>
         $("#add-offer").on("click", function () {
             var index = $("#offerings .offering").length;
-            var locOptions = $("select[name='Offerings[0].CraftLocationId']").html();
-            var packOptions = $("select[name='Offerings[0].CraftPackageId']").html();
             var template = `<div class='offering border p-2 mb-2'>` +
-                `<select name='Offerings[${index}].CraftLocationId' class='form-control'>` + locOptions + `</select>` +
-                `<select name='Offerings[${index}].CraftPackageId' class='form-control'>` + packOptions + `</select>` +
+                `<input name='Offerings[${index}].LocationName' class='form-control mb-1' placeholder='Location' />` +
+                `<input name='Offerings[${index}].SessionsCount' type='number' min='0' max='20' class='form-control mb-1' placeholder='Sessions' />` +
+                `<input name='Offerings[${index}].PackageLabel' class='form-control mb-1' placeholder='Label' />` +
                 `<input name='Offerings[${index}].Price' class='form-control' placeholder='Price' />` +
                 `</div>`;
             $("#offerings").append(template);


### PR DESCRIPTION
## Summary
- update craft offering view model to allow entering a location name and package data
- drop dropdowns from create/edit craft forms so masters type their own offerings
- update controller to create CraftLocation and CraftPackage records for each offering

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871734cf35c8330bf1c9bbee16ef37f