### PR TITLE
Implement soft delete for craft entities

### DIFF
--- a/smelite_app/smelite_app/Data/ApplicationDbContext.cs
+++ b/smelite_app/smelite_app/Data/ApplicationDbContext.cs
@@ -31,6 +31,10 @@ namespace smelite_app.Data
         {
             base.OnModelCreating(builder);
 
+            builder.Entity<Craft>().HasQueryFilter(c => !c.IsDeleted);
+            builder.Entity<CraftType>().HasQueryFilter(ct => !ct.IsDeleted);
+            builder.Entity<CraftOffering>().HasQueryFilter(co => !co.IsDeleted);
+
             builder.Entity<ApplicationUser>()
                 .HasOne(u => u.MasterProfile)
                 .WithOne(mp => mp.ApplicationUser)

--- a/smelite_app/smelite_app/Migrations/20250710211018_Initial.Designer.cs
+++ b/smelite_app/smelite_app/Migrations/20250710211018_Initial.Designer.cs
@@ -318,6 +318,9 @@ namespace smelite_app.Migrations
                     b.Property<int>("ExperienceYears")
                         .HasColumnType("int");
 
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(300)
@@ -391,6 +394,9 @@ namespace smelite_app.Migrations
                     b.Property<decimal>("Price")
                         .HasColumnType("decimal(10,4)");
 
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
                     b.HasKey("Id");
 
                     b.HasIndex("CraftId");
@@ -434,6 +440,9 @@ namespace smelite_app.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
 
                     b.HasKey("Id");
 

--- a/smelite_app/smelite_app/Migrations/20250710211018_Initial.cs
+++ b/smelite_app/smelite_app/Migrations/20250710211018_Initial.cs
@@ -87,7 +87,8 @@ namespace smelite_app.Migrations
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false)
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false)
                 },
                 constraints: table =>
                 {
@@ -249,7 +250,8 @@ namespace smelite_app.Migrations
                     CraftTypeId = table.Column<int>(type: "int", nullable: false),
                     Name = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: false),
                     CraftDescription = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: true),
-                    ExperienceYears = table.Column<int>(type: "int", nullable: false)
+                    ExperienceYears = table.Column<int>(type: "int", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false)
                 },
                 constraints: table =>
                 {
@@ -291,7 +293,8 @@ namespace smelite_app.Migrations
                     CraftId = table.Column<int>(type: "int", nullable: false),
                     CraftLocationId = table.Column<int>(type: "int", nullable: false),
                     CraftPackageId = table.Column<int>(type: "int", nullable: false),
-                    Price = table.Column<decimal>(type: "decimal(10,4)", nullable: false)
+                    Price = table.Column<decimal>(type: "decimal(10,4)", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false)
                 },
                 constraints: table =>
                 {

--- a/smelite_app/smelite_app/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/smelite_app/smelite_app/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -315,6 +315,9 @@ namespace smelite_app.Migrations
                     b.Property<int>("ExperienceYears")
                         .HasColumnType("int");
 
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(300)
@@ -388,6 +391,9 @@ namespace smelite_app.Migrations
                     b.Property<decimal>("Price")
                         .HasColumnType("decimal(10,4)");
 
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
                     b.HasKey("Id");
 
                     b.HasIndex("CraftId");
@@ -431,6 +437,9 @@ namespace smelite_app.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
 
                     b.HasKey("Id");
 

--- a/smelite_app/smelite_app/Models/Craft.cs
+++ b/smelite_app/smelite_app/Models/Craft.cs
@@ -19,6 +19,8 @@ namespace smelite_app.Models
         [Range(0, 100)]
         public int ExperienceYears { get; set; }
 
+        public bool IsDeleted { get; set; } = false;
+
         public ICollection<CraftImage> Images { get; set; }
         public ICollection<MasterProfileCraft> MasterProfileCrafts { get; set; }
         public ICollection<CraftOffering> CraftOfferings { get; set; }

--- a/smelite_app/smelite_app/Models/CraftOffering.cs
+++ b/smelite_app/smelite_app/Models/CraftOffering.cs
@@ -22,5 +22,7 @@ namespace smelite_app.Models
         [Required]
         [Column(TypeName = "decimal(10,4)")]
         public decimal Price { get; set; }
+
+        public bool IsDeleted { get; set; } = false;
     }
 }

--- a/smelite_app/smelite_app/Models/CraftType.cs
+++ b/smelite_app/smelite_app/Models/CraftType.cs
@@ -10,6 +10,8 @@ namespace smelite_app.Models
         [MaxLength(200)]
         public string Name { get; set; }
 
+        public bool IsDeleted { get; set; } = false;
+
         public ICollection<Craft> Crafts { get; set; }
     }
 

--- a/smelite_app/smelite_app/Repositories/CraftRepository.cs
+++ b/smelite_app/smelite_app/Repositories/CraftRepository.cs
@@ -67,5 +67,37 @@ namespace smelite_app.Repositories
         {
             return _context.CraftPackages.ToListAsync();
         }
+
+        public async Task SoftDeleteCraftAsync(int craftId)
+        {
+            var craft = await _context.Crafts.FindAsync(craftId);
+            if (craft != null)
+            {
+                craft.IsDeleted = true;
+                var offerings = _context.CraftOfferings.Where(o => o.CraftId == craftId);
+                await offerings.ForEachAsync(o => o.IsDeleted = true);
+                await _context.SaveChangesAsync();
+            }
+        }
+
+        public async Task SoftDeleteCraftTypeAsync(int craftTypeId)
+        {
+            var type = await _context.CraftTypes.FindAsync(craftTypeId);
+            if (type != null)
+            {
+                type.IsDeleted = true;
+                await _context.SaveChangesAsync();
+            }
+        }
+
+        public async Task SoftDeleteCraftOfferingAsync(int offeringId)
+        {
+            var offering = await _context.CraftOfferings.FindAsync(offeringId);
+            if (offering != null)
+            {
+                offering.IsDeleted = true;
+                await _context.SaveChangesAsync();
+            }
+        }
     }
 }

--- a/smelite_app/smelite_app/Repositories/ICraftRepository.cs
+++ b/smelite_app/smelite_app/Repositories/ICraftRepository.cs
@@ -14,5 +14,9 @@ namespace smelite_app.Repositories
 
         Task<List<CraftLocation>> GetLocationsAsync();
         Task<List<CraftPackage>> GetPackagesAsync();
+
+        Task SoftDeleteCraftAsync(int craftId);
+        Task SoftDeleteCraftTypeAsync(int craftTypeId);
+        Task SoftDeleteCraftOfferingAsync(int offeringId);
     }
 }

--- a/smelite_app/smelite_app/Services/CraftService.cs
+++ b/smelite_app/smelite_app/Services/CraftService.cs
@@ -76,5 +76,20 @@ namespace smelite_app.Services
         {
             return _repository.GetPackagesAsync();
         }
+
+        public Task SoftDeleteCraftAsync(int craftId)
+        {
+            return _repository.SoftDeleteCraftAsync(craftId);
+        }
+
+        public Task SoftDeleteCraftTypeAsync(int craftTypeId)
+        {
+            return _repository.SoftDeleteCraftTypeAsync(craftTypeId);
+        }
+
+        public Task SoftDeleteCraftOfferingAsync(int offeringId)
+        {
+            return _repository.SoftDeleteCraftOfferingAsync(offeringId);
+        }
     }
 }

--- a/smelite_app/smelite_app/Services/ICraftService.cs
+++ b/smelite_app/smelite_app/Services/ICraftService.cs
@@ -12,5 +12,9 @@ namespace smelite_app.Services
         Task<List<CraftType>> GetCraftTypesAsync();
         Task<List<CraftLocation>> GetLocationsAsync();
         Task<List<CraftPackage>> GetPackagesAsync();
+
+        Task SoftDeleteCraftAsync(int craftId);
+        Task SoftDeleteCraftTypeAsync(int craftTypeId);
+        Task SoftDeleteCraftOfferingAsync(int offeringId);
     }
 }


### PR DESCRIPTION
## Summary
- add `IsDeleted` flags to Craft, CraftType and CraftOffering models
- apply global query filters for these flags in `ApplicationDbContext`
- include `IsDeleted` columns in the initial migration and snapshot
- expose soft delete operations via repository and service

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687182ef49308330a29b2f88b4206b4c