### PR TITLE
Enforce service layer pattern for master features

### DIFF
--- a/smelite_app/smelite_app/Services/IMasterService.cs
+++ b/smelite_app/smelite_app/Services/IMasterService.cs
@@ -1,15 +1,18 @@
 ﻿using smelite_app.Models;
+using smelite_app.ViewModels.Master;
 
 namespace smelite_app.Services
 {
     public interface IMasterService
     {
+        Task<MasterProfileViewModel?> GetProfileAsync(string userId);
         Task<MasterProfile?> GetByUserIdAsync(string userId);
         Task UpdateProfileAsync(MasterProfile profile);
-        Task AddCraftAsync(int masterProfileId, Craft craft, IEnumerable<CraftOffering> offerings, IEnumerable<CraftImage>? images);
+
+        Task AddCraftAsync(int masterProfileId, CraftViewModel model, string webRootPath, string userId);
         Task<List<Craft>> GetCraftsAsync(int masterProfileId);
         Task<Craft?> GetCraftByIdAsync(int craftId);
-        Task UpdateCraftAsync(Craft craft, IEnumerable<CraftOffering> offerings, IEnumerable<int>? removeImageIds, IEnumerable<CraftImage>? newImages);
+        Task UpdateCraftAsync(EditCraftViewModel model, int masterProfileId, string webRootPath, string userId);
         Task<List<Apprenticeship>> GetApprenticeshipsAsync(int masterProfileId);
     }
 }

--- a/smelite_app/smelite_app/Services/MasterService.cs
+++ b/smelite_app/smelite_app/Services/MasterService.cs
@@ -1,5 +1,10 @@
-﻿using smelite_app.Models;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using System.IO;
+using smelite_app.Models;
 using smelite_app.Repositories;
+using smelite_app.ViewModels.Master;
+using smelite_app.Helpers;
 
 namespace smelite_app.Services
 {
@@ -12,9 +17,25 @@ namespace smelite_app.Services
             _masterRepository = masterRepository
                 ?? throw new ArgumentNullException(nameof(masterRepository));
         }
+
         public Task<MasterProfile?> GetByUserIdAsync(string userId)
         {
             return _masterRepository.GetByUserIdAsync(userId);
+        }
+
+        public async Task<MasterProfileViewModel?> GetProfileAsync(string userId)
+        {
+            var profile = await _masterRepository.GetByUserIdAsync(userId);
+            if (profile == null) return null;
+
+            return new MasterProfileViewModel
+            {
+                FirstName = profile.ApplicationUser.FirstName,
+                LastName = profile.ApplicationUser.LastName,
+                Email = profile.ApplicationUser.Email!,
+                ProfileImageUrl = profile.ApplicationUser.ProfileImageUrl,
+                PersonalInformation = profile.PersonalInformation
+            };
         }
 
         public Task UpdateProfileAsync(MasterProfile profile)
@@ -22,9 +43,44 @@ namespace smelite_app.Services
             return _masterRepository.UpdateProfileAsync(profile);
         }
 
-        public Task AddCraftAsync(int masterProfileId, Craft craft, IEnumerable<CraftOffering> offerings, IEnumerable<CraftImage>? images)
+        public async Task AddCraftAsync(int masterProfileId, CraftViewModel model, string webRootPath, string userId)
         {
-            return _masterRepository.AddCraftAsync(masterProfileId, craft, offerings, images);
+            var craft = new Craft
+            {
+                Name = model.Name,
+                CraftDescription = model.CraftDescription,
+                ExperienceYears = model.ExperienceYears,
+                CraftTypeId = model.CraftTypeId
+            };
+
+            var offerings = model.Offerings.Select(o => new CraftOffering
+            {
+                CraftLocation = new CraftLocation { Name = o.LocationName },
+                CraftPackage = new CraftPackage { SessionsCount = o.SessionsCount, Label = o.PackageLabel },
+                Price = o.Price
+            }).ToList();
+
+            var images = new List<CraftImage>();
+            if (model.Images != null)
+            {
+                var uploads = Path.Combine(webRootPath, "CraftsImages");
+                Directory.CreateDirectory(uploads);
+                foreach (var file in model.Images)
+                {
+                    if (file.Length == 0) continue;
+                    var fileName = $"{userId}_{Guid.NewGuid()}{Path.GetExtension(file.FileName)}";
+                    var filePath = Path.Combine(uploads, fileName);
+                    using var stream = new FileStream(filePath, FileMode.Create);
+                    await file.CopyToAsync(stream);
+                    images.Add(new CraftImage { ImageUrl = "/CraftsImages/" + fileName });
+                }
+            }
+            else
+            {
+                images.Add(new CraftImage { ImageUrl = Variables.defaultCraftImageUrl });
+            }
+
+            await _masterRepository.AddCraftAsync(masterProfileId, craft, offerings, images);
         }
 
         public Task<List<Craft>> GetCraftsAsync(int masterProfileId)
@@ -37,9 +93,39 @@ namespace smelite_app.Services
             return _masterRepository.GetCraftByIdAsync(craftId);
         }
 
-        public Task UpdateCraftAsync(Craft craft, IEnumerable<CraftOffering> offerings, IEnumerable<int>? removeImageIds, IEnumerable<CraftImage>? newImages)
+        public async Task UpdateCraftAsync(EditCraftViewModel model, int masterProfileId, string webRootPath, string userId)
         {
-            return _masterRepository.UpdateCraftAsync(craft, offerings, removeImageIds, newImages);
+            var craft = await _masterRepository.GetCraftByIdAsync(model.Id) ?? throw new InvalidOperationException();
+
+            craft.Name = model.Name;
+            craft.CraftDescription = model.CraftDescription;
+            craft.ExperienceYears = model.ExperienceYears;
+            craft.CraftTypeId = model.CraftTypeId;
+
+            var offerings = model.Offerings.Select(o => new CraftOffering
+            {
+                CraftLocation = new CraftLocation { Name = o.LocationName },
+                CraftPackage = new CraftPackage { SessionsCount = o.SessionsCount, Label = o.PackageLabel },
+                Price = o.Price
+            }).ToList();
+
+            var newImages = new List<CraftImage>();
+            if (model.Images != null)
+            {
+                var uploads = Path.Combine(webRootPath, "CraftsImages");
+                Directory.CreateDirectory(uploads);
+                foreach (var file in model.Images)
+                {
+                    if (file.Length == 0) continue;
+                    var fileName = $"{userId}_{Guid.NewGuid()}{Path.GetExtension(file.FileName)}";
+                    var filePath = Path.Combine(uploads, fileName);
+                    using var stream = new FileStream(filePath, FileMode.Create);
+                    await file.CopyToAsync(stream);
+                    newImages.Add(new CraftImage { ImageUrl = "/CraftsImages/" + fileName });
+                }
+            }
+
+            await _masterRepository.UpdateCraftAsync(craft, offerings, model.RemoveImageIds, newImages);
         }
 
         public Task<List<Apprenticeship>> GetApprenticeshipsAsync(int masterProfileId)

--- a/smelite_app/smelite_app/ViewModels/Master/MasterCraftListItemViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Master/MasterCraftListItemViewModel.cs
@@ -1,0 +1,9 @@
+namespace smelite_app.ViewModels.Master
+{
+    public class MasterCraftListItemViewModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+    }
+}

--- a/smelite_app/smelite_app/ViewModels/Master/MasterProfileViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Master/MasterProfileViewModel.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace smelite_app.ViewModels.Master
+{
+    public class MasterProfileViewModel
+    {
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string? ProfileImageUrl { get; set; }
+        public string? PersonalInformation { get; set; }
+    }
+}

--- a/smelite_app/smelite_app/Views/Master/Crafts.cshtml
+++ b/smelite_app/smelite_app/Views/Master/Crafts.cshtml
@@ -1,11 +1,11 @@
-@model IEnumerable<smelite_app.Models.Craft>
+@model IEnumerable<smelite_app.ViewModels.Master.MasterCraftListItemViewModel>
 
 <h2>Your Crafts</h2>
 <ul>
 @foreach (var c in Model)
 {
     <li>
-        @c.Name (@c.CraftType?.Name)
+        @c.Name (@c.Type)
         <a asp-action="EditCraft" asp-route-id="@c.Id">Edit</a>
     </li>
 }

--- a/smelite_app/smelite_app/Views/Master/Profile.cshtml
+++ b/smelite_app/smelite_app/Views/Master/Profile.cshtml
@@ -1,10 +1,10 @@
-@model smelite_app.Models.MasterProfile
+@model smelite_app.ViewModels.Master.MasterProfileViewModel
 
 <h2>Master Profile</h2>
 
 <div class="mb-3">
-    <p>Name: @Model.ApplicationUser.FirstName @Model.ApplicationUser.LastName</p>
-    <p>Email: @Model.ApplicationUser.Email</p>
+    <p>Name: @Model.FirstName @Model.LastName</p>
+    <p>Email: @Model.Email</p>
     <p>Info: @Model.PersonalInformation</p>
 </div>
 


### PR DESCRIPTION
## Summary
- add dedicated view models for master profile and craft listing
- move craft creation and editing logic to service layer
- use new service methods in controller
- ensure views consume view models instead of entities

## Testing
- `dotnet build smelite_app/smelite_app.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872397a4e988330a787bac8acd279cc