### PR TITLE
Allow masters to deactivate crafts and offerings

### DIFF
--- a/smelite_app/smelite_app/Repositories/CraftRepository.cs
+++ b/smelite_app/smelite_app/Repositories/CraftRepository.cs
@@ -68,6 +68,22 @@ namespace smelite_app.Repositories
             return _context.CraftPackages.ToListAsync();
         }
 
+        public Task<CraftOffering?> GetCraftOfferingByIdAsync(int offeringId)
+        {
+            return _context.CraftOfferings
+                .Include(o => o.Craft)
+                    .ThenInclude(c => c.MasterProfileCrafts)
+                .FirstOrDefaultAsync(o => o.Id == offeringId);
+        }
+
+        public Task<CraftImage?> GetCraftImageByIdAsync(int imageId)
+        {
+            return _context.CraftImages
+                .Include(i => i.Craft)
+                    .ThenInclude(c => c.MasterProfileCrafts)
+                .FirstOrDefaultAsync(i => i.Id == imageId);
+        }
+
         public async Task SoftDeleteCraftAsync(int craftId)
         {
             var craft = await _context.Crafts.FindAsync(craftId);
@@ -96,6 +112,16 @@ namespace smelite_app.Repositories
             if (offering != null)
             {
                 offering.IsDeleted = true;
+                await _context.SaveChangesAsync();
+            }
+        }
+
+        public async Task RemoveCraftImageAsync(int imageId)
+        {
+            var img = await _context.CraftImages.FindAsync(imageId);
+            if (img != null)
+            {
+                _context.CraftImages.Remove(img);
                 await _context.SaveChangesAsync();
             }
         }

--- a/smelite_app/smelite_app/Repositories/ICraftRepository.cs
+++ b/smelite_app/smelite_app/Repositories/ICraftRepository.cs
@@ -15,8 +15,12 @@ namespace smelite_app.Repositories
         Task<List<CraftLocation>> GetLocationsAsync();
         Task<List<CraftPackage>> GetPackagesAsync();
 
+        Task<CraftOffering?> GetCraftOfferingByIdAsync(int offeringId);
+        Task<CraftImage?> GetCraftImageByIdAsync(int imageId);
+
         Task SoftDeleteCraftAsync(int craftId);
         Task SoftDeleteCraftTypeAsync(int craftTypeId);
         Task SoftDeleteCraftOfferingAsync(int offeringId);
+        Task RemoveCraftImageAsync(int imageId);
     }
 }

--- a/smelite_app/smelite_app/Services/CraftService.cs
+++ b/smelite_app/smelite_app/Services/CraftService.cs
@@ -77,6 +77,16 @@ namespace smelite_app.Services
             return _repository.GetPackagesAsync();
         }
 
+        public Task<CraftOffering?> GetCraftOfferingByIdAsync(int id)
+        {
+            return _repository.GetCraftOfferingByIdAsync(id);
+        }
+
+        public Task<CraftImage?> GetCraftImageByIdAsync(int id)
+        {
+            return _repository.GetCraftImageByIdAsync(id);
+        }
+
         public Task SoftDeleteCraftAsync(int craftId)
         {
             return _repository.SoftDeleteCraftAsync(craftId);
@@ -90,6 +100,11 @@ namespace smelite_app.Services
         public Task SoftDeleteCraftOfferingAsync(int offeringId)
         {
             return _repository.SoftDeleteCraftOfferingAsync(offeringId);
+        }
+
+        public Task RemoveCraftImageAsync(int imageId)
+        {
+            return _repository.RemoveCraftImageAsync(imageId);
         }
     }
 }

--- a/smelite_app/smelite_app/Services/ICraftService.cs
+++ b/smelite_app/smelite_app/Services/ICraftService.cs
@@ -13,8 +13,12 @@ namespace smelite_app.Services
         Task<List<CraftLocation>> GetLocationsAsync();
         Task<List<CraftPackage>> GetPackagesAsync();
 
+        Task<CraftOffering?> GetCraftOfferingByIdAsync(int id);
+        Task<CraftImage?> GetCraftImageByIdAsync(int id);
+
         Task SoftDeleteCraftAsync(int craftId);
         Task SoftDeleteCraftTypeAsync(int craftTypeId);
         Task SoftDeleteCraftOfferingAsync(int offeringId);
+        Task RemoveCraftImageAsync(int imageId);
     }
 }

--- a/smelite_app/smelite_app/ViewModels/Craft/CraftOfferingFormViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Craft/CraftOfferingFormViewModel.cs
@@ -4,6 +4,8 @@ namespace smelite_app.ViewModels.Master
 {
     public class CraftOfferingFormViewModel
     {
+        public int? Id { get; set; }
+
         [Required]
         [MaxLength(300)]
         [Display(Name = "Location")]

--- a/smelite_app/smelite_app/Views/Master/Crafts.cshtml
+++ b/smelite_app/smelite_app/Views/Master/Crafts.cshtml
@@ -7,6 +7,9 @@
     <li>
         @c.Name (@c.Type)
         <a asp-action="EditCraft" asp-route-id="@c.Id">Edit</a>
+        <form asp-action="DeleteCraft" asp-route-id="@c.Id" method="post" class="d-inline">
+            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
     </li>
 }
 </ul>

--- a/smelite_app/smelite_app/Views/Master/EditCraft.cshtml
+++ b/smelite_app/smelite_app/Views/Master/EditCraft.cshtml
@@ -30,6 +30,7 @@
                 <div class="form-check mb-1">
                     <img src="@img.Url" class="img-fluid" style="max-height:150px;" />
                     <input type="checkbox" name="RemoveImageIds" value="@img.Id" class="form-check-input" /> Remove
+                    <button type="submit" formaction="@Url.Action("DeleteImage", "Master", new { id = img.Id })" formmethod="post" class="btn btn-sm btn-danger ms-2">Delete</button>
                 </div>
             }
         </div>
@@ -40,10 +41,15 @@
         @for (int i = 0; i < Model.Offerings.Count; i++)
         {
             <div class="offering border p-2 mb-2">
+                <input type="hidden" asp-for="Offerings[i].Id" />
                 <input asp-for="Offerings[i].LocationName" placeholder="Location" class="form-control mb-1" />
                 <input asp-for="Offerings[i].SessionsCount" type="number" min="0" max="20" placeholder="Sessions" class="form-control mb-1" />
                 <input asp-for="Offerings[i].PackageLabel" placeholder="Label" class="form-control mb-1" />
                 <input asp-for="Offerings[i].Price" placeholder="Price" class="form-control" />
+                @if (Model.Offerings[i].Id != null)
+                {
+                    <button type="submit" formaction="@Url.Action("DeleteCraftOffering", "Master", new { id = Model.Offerings[i].Id })" formmethod="post" class="btn btn-sm btn-danger mt-1">Remove</button>
+                }
             </div>
         }
     </div>


### PR DESCRIPTION
## Summary
- let Master remove their craft images
- add endpoints for removing craft offerings and crafts via soft delete
- expose helpers in craft repository/service for fetching and removing images and offerings
- show delete buttons in EditCraft and Crafts list

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723e2574a4833096cb3d52f50fb4b2