### PR TITLE
Add HTML input limits and antiforgery

### DIFF
--- a/smelite_app/smelite_app/Controllers/MasterController.cs
+++ b/smelite_app/smelite_app/Controllers/MasterController.cs
@@ -59,6 +59,7 @@ namespace smelite_app.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> EditProfile(EditMasterProfileViewModel model)
         {
             if (!ModelState.IsValid) return View(model);
@@ -143,6 +144,7 @@ namespace smelite_app.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> CreateCraft(CraftViewModel craft)
         {
             if (!ModelState.IsValid)
@@ -213,6 +215,7 @@ namespace smelite_app.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> EditCraft(EditCraftViewModel model)
         {
             if (!ModelState.IsValid)

--- a/smelite_app/smelite_app/Views/Master/CreateCraft.cshtml
+++ b/smelite_app/smelite_app/Views/Master/CreateCraft.cshtml
@@ -5,7 +5,7 @@
 <form asp-action="CreateCraft" method="post" enctype="multipart/form-data">
     <div>
         <label asp-for="Name"></label>
-        <input asp-for="Name" />
+        <input asp-for="Name" maxlength="300" required />
     </div>
     <div>
         <label asp-for="CraftTypeId"></label>
@@ -15,11 +15,11 @@
     </div>
     <div>
         <label asp-for="CraftDescription"></label>
-        <textarea asp-for="CraftDescription"></textarea>
+        <textarea asp-for="CraftDescription" maxlength="1000"></textarea>
     </div>
     <div>
         <label asp-for="ExperienceYears"></label>
-        <input asp-for="ExperienceYears" type="number" />
+        <input asp-for="ExperienceYears" type="number" min="0" max="100" />
     </div>
     <div>
         <label>Images</label>
@@ -29,10 +29,10 @@
         @for (int i = 0; i < Model.Offerings.Count; i++)
         {
             <div class="offering border p-2 mb-2">
-                <input asp-for="Offerings[i].LocationName" placeholder="Location" class="form-control mb-1" />
-                <input asp-for="Offerings[i].SessionsCount" type="number" min="0" max="20" placeholder="Sessions" class="form-control mb-1" />
-                <input asp-for="Offerings[i].PackageLabel" placeholder="Label" class="form-control mb-1" />
-                <input asp-for="Offerings[i].Price" placeholder="Price" class="form-control" />
+                <input asp-for="Offerings[i].LocationName" placeholder="Location" class="form-control mb-1" maxlength="300" required />
+                <input asp-for="Offerings[i].SessionsCount" type="number" min="0" max="20" placeholder="Sessions" class="form-control mb-1" required />
+                <input asp-for="Offerings[i].PackageLabel" placeholder="Label" class="form-control mb-1" maxlength="100" />
+                <input asp-for="Offerings[i].Price" placeholder="Price" class="form-control" type="number" min="0" max="100000" step="0.01" required />
             </div>
         }
     </div>
@@ -45,10 +45,10 @@
         $("#add-offer").on("click", function () {
             var index = $("#offerings .offering").length;
             var template = `<div class='offering border p-2 mb-2'>` +
-                `<input name='Offerings[${index}].LocationName' class='form-control mb-1' placeholder='Location' />` +
-                `<input name='Offerings[${index}].SessionsCount' type='number' min='0' max='20' class='form-control mb-1' placeholder='Sessions' />` +
-                `<input name='Offerings[${index}].PackageLabel' class='form-control mb-1' placeholder='Label' />` +
-                `<input name='Offerings[${index}].Price' class='form-control' placeholder='Price' />` +
+                `<input name='Offerings[${index}].LocationName' class='form-control mb-1' placeholder='Location' maxlength='300' required />` +
+                `<input name='Offerings[${index}].SessionsCount' type='number' min='0' max='20' class='form-control mb-1' placeholder='Sessions' required />` +
+                `<input name='Offerings[${index}].PackageLabel' class='form-control mb-1' placeholder='Label' maxlength='100' />` +
+                `<input name='Offerings[${index}].Price' class='form-control' placeholder='Price' type='number' min='0' max='100000' step='0.01' required />` +
                 `</div>`;
             $("#offerings").append(template);
         });

--- a/smelite_app/smelite_app/Views/Master/EditCraft.cshtml
+++ b/smelite_app/smelite_app/Views/Master/EditCraft.cshtml
@@ -6,7 +6,7 @@
     <input type="hidden" asp-for="Id" />
     <div>
         <label asp-for="Name"></label>
-        <input asp-for="Name" />
+        <input asp-for="Name" maxlength="300" required />
     </div>
     <div>
         <label asp-for="CraftTypeId"></label>
@@ -16,11 +16,11 @@
     </div>
     <div>
         <label asp-for="CraftDescription"></label>
-        <textarea asp-for="CraftDescription"></textarea>
+        <textarea asp-for="CraftDescription" maxlength="1000"></textarea>
     </div>
     <div>
         <label asp-for="ExperienceYears"></label>
-        <input asp-for="ExperienceYears" type="number" />
+        <input asp-for="ExperienceYears" type="number" min="0" max="100" />
     </div>
     <div>
         <label>Existing Images</label>
@@ -42,10 +42,10 @@
         {
             <div class="offering border p-2 mb-2">
                 <input type="hidden" asp-for="Offerings[i].Id" />
-                <input asp-for="Offerings[i].LocationName" placeholder="Location" class="form-control mb-1" />
-                <input asp-for="Offerings[i].SessionsCount" type="number" min="0" max="20" placeholder="Sessions" class="form-control mb-1" />
-                <input asp-for="Offerings[i].PackageLabel" placeholder="Label" class="form-control mb-1" />
-                <input asp-for="Offerings[i].Price" placeholder="Price" class="form-control" />
+                <input asp-for="Offerings[i].LocationName" placeholder="Location" class="form-control mb-1" maxlength="300" required />
+                <input asp-for="Offerings[i].SessionsCount" type="number" min="0" max="20" placeholder="Sessions" class="form-control mb-1" required />
+                <input asp-for="Offerings[i].PackageLabel" placeholder="Label" class="form-control mb-1" maxlength="100" />
+                <input asp-for="Offerings[i].Price" placeholder="Price" class="form-control" type="number" min="0" max="100000" step="0.01" required />
                 @if (Model.Offerings[i].Id != null)
                 {
                     <button type="submit" formaction="@Url.Action("DeleteCraftOffering", "Master", new { id = Model.Offerings[i].Id })" formmethod="post" class="btn btn-sm btn-danger mt-1">Remove</button>
@@ -62,10 +62,10 @@
         $("#add-offer").on("click", function () {
             var index = $("#offerings .offering").length;
             var template = `<div class='offering border p-2 mb-2'>` +
-                `<input name='Offerings[${index}].LocationName' class='form-control mb-1' placeholder='Location' />` +
-                `<input name='Offerings[${index}].SessionsCount' type='number' min='0' max='20' class='form-control mb-1' placeholder='Sessions' />` +
-                `<input name='Offerings[${index}].PackageLabel' class='form-control mb-1' placeholder='Label' />` +
-                `<input name='Offerings[${index}].Price' class='form-control' placeholder='Price' />` +
+                `<input name='Offerings[${index}].LocationName' class='form-control mb-1' placeholder='Location' maxlength='300' required />` +
+                `<input name='Offerings[${index}].SessionsCount' type='number' min='0' max='20' class='form-control mb-1' placeholder='Sessions' required />` +
+                `<input name='Offerings[${index}].PackageLabel' class='form-control mb-1' placeholder='Label' maxlength='100' />` +
+                `<input name='Offerings[${index}].Price' class='form-control' placeholder='Price' type='number' min='0' max='100000' step='0.01' required />` +
                 `</div>`;
             $("#offerings").append(template);
         });

--- a/smelite_app/smelite_app/Views/Master/EditProfile.cshtml
+++ b/smelite_app/smelite_app/Views/Master/EditProfile.cshtml
@@ -5,15 +5,15 @@
 <form asp-action="EditProfile" method="post" enctype="multipart/form-data">
     <div>
         <label asp-for="FirstName"></label>
-        <input asp-for="FirstName" />
+        <input asp-for="FirstName" maxlength="100" required />
     </div>
     <div>
         <label asp-for="LastName"></label>
-        <input asp-for="LastName" />
+        <input asp-for="LastName" maxlength="100" required />
     </div>
     <div>
         <label asp-for="Email"></label>
-        <input asp-for="Email" />
+        <input asp-for="Email" type="email" required />
     </div>
     <div class="mb-3">
         <label>Profile Image</label>
@@ -25,7 +25,7 @@
     </div>
     <div>
         <label asp-for="PersonalInformation"></label>
-        <textarea asp-for="PersonalInformation"></textarea>
+        <textarea asp-for="PersonalInformation" maxlength="2000"></textarea>
     </div>
     <div>
         <label asp-for="CurrentPassword"></label>


### PR DESCRIPTION
## Summary
- add `maxlength`, numeric ranges and required flags in master views
- update dynamic form templates with same restrictions
- guard master POST actions with `ValidateAntiForgeryToken`

## Testing
- `dotnet build -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68724a329fc88330990b4437031ccffb