### PR TITLE
Add apprentice profile features and ordering

### DIFF
--- a/smelite_app/smelite_app/Controllers/ApprenticeController.cs
+++ b/smelite_app/smelite_app/Controllers/ApprenticeController.cs
@@ -1,24 +1,152 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
+using smelite_app.Models;
+using smelite_app.Services;
+using smelite_app.ViewModels.Apprentice;
 
 namespace smelite_app.Controllers
 {
     [Authorize(Roles = "Apprentice")]
     public class ApprenticeController : Controller
     {
-        public IActionResult Profile()
+        private readonly IApprenticeService _apprenticeService;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IWebHostEnvironment _environment;
+
+        public ApprenticeController(IApprenticeService apprenticeService, UserManager<ApplicationUser> userManager, IWebHostEnvironment environment)
         {
-            return View();
+            _apprenticeService = apprenticeService;
+            _userManager = userManager;
+            _environment = environment;
         }
 
-        public IActionResult CreateCraft()
+        public async Task<IActionResult> Profile()
         {
-            return View();
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) return NotFound();
+
+            var profile = await _apprenticeService.GetProfileAsync(user.Id);
+            if (profile == null) return NotFound();
+
+            return View(profile);
         }
 
-        public IActionResult Sessions()
+        [HttpGet]
+        public async Task<IActionResult> EditProfile()
         {
-            return View();
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) return NotFound();
+
+            var profile = await _apprenticeService.GetByUserIdAsync(user.Id);
+            if (profile == null) return NotFound();
+
+            var vm = new EditApprenticeProfileViewModel
+            {
+                FirstName = user.FirstName,
+                LastName = user.LastName,
+                Email = user.Email!,
+                PersonalInformation = profile.PersonalInformation,
+                ProfileImageUrl = user.ProfileImageUrl
+            };
+            return View(vm);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> EditProfile(EditApprenticeProfileViewModel model)
+        {
+            if (!ModelState.IsValid) return View(model);
+
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) return NotFound();
+
+            var profile = await _apprenticeService.GetByUserIdAsync(user.Id);
+            if (profile == null) return NotFound();
+
+            bool userChanged = false;
+            if (user.FirstName != model.FirstName)
+            {
+                user.FirstName = model.FirstName;
+                userChanged = true;
+            }
+            if (user.LastName != model.LastName)
+            {
+                user.LastName = model.LastName;
+                userChanged = true;
+            }
+            if (user.Email != model.Email)
+            {
+                user.Email = model.Email;
+                user.UserName = model.Email;
+                userChanged = true;
+            }
+            if (model.ProfileImage != null && model.ProfileImage.Length > 0)
+            {
+                var uploads = Path.Combine(_environment.WebRootPath, "ProfileImages");
+                Directory.CreateDirectory(uploads);
+                var fileName = Guid.NewGuid().ToString() + Path.GetExtension(model.ProfileImage.FileName);
+                var filePath = Path.Combine(uploads, fileName);
+                using (var stream = new FileStream(filePath, FileMode.Create))
+                {
+                    await model.ProfileImage.CopyToAsync(stream);
+                }
+                model.ProfileImageUrl = "/ProfileImages/" + fileName;
+            }
+            if (user.ProfileImageUrl != model.ProfileImageUrl)
+            {
+                user.ProfileImageUrl = model.ProfileImageUrl;
+                userChanged = true;
+            }
+
+            if (userChanged)
+                await _userManager.UpdateAsync(user);
+
+            if (!string.IsNullOrEmpty(model.NewPassword))
+            {
+                if (string.IsNullOrEmpty(model.CurrentPassword))
+                {
+                    ModelState.AddModelError("CurrentPassword", "Current password is required.");
+                    return View(model);
+                }
+
+                var result = await _userManager.ChangePasswordAsync(user, model.CurrentPassword!, model.NewPassword!);
+                if (!result.Succeeded)
+                {
+                    foreach (var error in result.Errors)
+                        ModelState.AddModelError(string.Empty, error.Description);
+                    return View(model);
+                }
+            }
+
+            profile.PersonalInformation = model.PersonalInformation;
+            await _apprenticeService.UpdateProfileAsync(profile);
+
+            return RedirectToAction(nameof(Profile));
+        }
+
+        public async Task<IActionResult> Sessions()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            var profile = await _apprenticeService.GetByUserIdAsync(user!.Id);
+            if (profile == null) return NotFound();
+
+            var apps = await _apprenticeService.GetApprenticeshipsAsync(profile.Id);
+            return View(apps);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Order(int offeringId)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            var profile = await _apprenticeService.GetByUserIdAsync(user!.Id);
+            if (profile == null) return NotFound();
+
+            await _apprenticeService.AddApprenticeshipAsync(profile.Id, offeringId);
+            return RedirectToAction(nameof(Sessions));
         }
     }
 }

--- a/smelite_app/smelite_app/Program.cs
+++ b/smelite_app/smelite_app/Program.cs
@@ -32,6 +32,7 @@ namespace smelite_app
             builder.Services.AddScoped<Repositories.IMasterRepository, Repositories.MasterRepository>();
 
             builder.Services.AddScoped<Services.ICraftService, Services.CraftService>();
+            builder.Services.AddScoped<Services.IApprenticeService, Services.ApprenticeService>();
             builder.Services.AddScoped<Services.IMasterService, Services.MasterService>();
             builder.Services.AddScoped<Services.IAccountService, Services.AccountService>();
 

--- a/smelite_app/smelite_app/Repositories/ApprenticeRepository.cs
+++ b/smelite_app/smelite_app/Repositories/ApprenticeRepository.cs
@@ -1,4 +1,5 @@
-﻿using smelite_app.Data;
+using Microsoft.EntityFrameworkCore;
+using smelite_app.Data;
 using smelite_app.Models;
 
 namespace smelite_app.Repositories
@@ -10,10 +11,41 @@ namespace smelite_app.Repositories
         {
             _context = context;
         }
+
         public async Task AddProfileAsync(ApprenticeProfile profile)
         {
             _context.ApprenticeProfiles.Add(profile);
             await _context.SaveChangesAsync();
+        }
+
+        public Task<ApprenticeProfile?> GetByUserIdAsync(string userId)
+        {
+            return _context.ApprenticeProfiles
+                .Include(ap => ap.ApplicationUser)
+                .FirstOrDefaultAsync(ap => ap.ApplicationUserId == userId);
+        }
+
+        public async Task UpdateProfileAsync(ApprenticeProfile profile)
+        {
+            _context.ApprenticeProfiles.Update(profile);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task AddApprenticeshipAsync(Apprenticeship apprenticeship)
+        {
+            _context.Apprenticeships.Add(apprenticeship);
+            await _context.SaveChangesAsync();
+        }
+
+        public Task<List<Apprenticeship>> GetApprenticeshipsAsync(int apprenticeProfileId)
+        {
+            return _context.Apprenticeships
+                .Include(a => a.MasterProfile)
+                    .ThenInclude(mp => mp.ApplicationUser)
+                .Include(a => a.CraftOffering)
+                    .ThenInclude(o => o.Craft)
+                .Where(a => a.ApprenticeProfileId == apprenticeProfileId)
+                .ToListAsync();
         }
     }
 }

--- a/smelite_app/smelite_app/Repositories/IApprenticeRepository.cs
+++ b/smelite_app/smelite_app/Repositories/IApprenticeRepository.cs
@@ -1,9 +1,14 @@
-﻿using smelite_app.Models;
+using smelite_app.Models;
 
 namespace smelite_app.Repositories
 {
     public interface IApprenticeRepository
     {
         Task AddProfileAsync(ApprenticeProfile profile);
+        Task<ApprenticeProfile?> GetByUserIdAsync(string userId);
+        Task UpdateProfileAsync(ApprenticeProfile profile);
+
+        Task AddApprenticeshipAsync(Apprenticeship apprenticeship);
+        Task<List<Apprenticeship>> GetApprenticeshipsAsync(int apprenticeProfileId);
     }
 }

--- a/smelite_app/smelite_app/Services/ApprenticeService.cs
+++ b/smelite_app/smelite_app/Services/ApprenticeService.cs
@@ -1,0 +1,65 @@
+using smelite_app.Enums;
+using smelite_app.Models;
+using smelite_app.Repositories;
+using smelite_app.ViewModels.Apprentice;
+
+namespace smelite_app.Services
+{
+    public class ApprenticeService : IApprenticeService
+    {
+        private readonly IApprenticeRepository _apprenticeRepository;
+        private readonly ICraftRepository _craftRepository;
+
+        public ApprenticeService(IApprenticeRepository apprenticeRepository, ICraftRepository craftRepository)
+        {
+            _apprenticeRepository = apprenticeRepository ?? throw new ArgumentNullException(nameof(apprenticeRepository));
+            _craftRepository = craftRepository ?? throw new ArgumentNullException(nameof(craftRepository));
+        }
+
+        public Task<ApprenticeProfile?> GetByUserIdAsync(string userId)
+        {
+            return _apprenticeRepository.GetByUserIdAsync(userId);
+        }
+
+        public async Task<ApprenticeProfileViewModel?> GetProfileAsync(string userId)
+        {
+            var profile = await _apprenticeRepository.GetByUserIdAsync(userId);
+            if (profile == null) return null;
+
+            return new ApprenticeProfileViewModel
+            {
+                FirstName = profile.ApplicationUser.FirstName,
+                LastName = profile.ApplicationUser.LastName,
+                Email = profile.ApplicationUser.Email!,
+                ProfileImageUrl = profile.ApplicationUser.ProfileImageUrl,
+                PersonalInformation = profile.PersonalInformation
+            };
+        }
+
+        public Task UpdateProfileAsync(ApprenticeProfile profile)
+        {
+            return _apprenticeRepository.UpdateProfileAsync(profile);
+        }
+
+        public async Task AddApprenticeshipAsync(int apprenticeProfileId, int craftOfferingId)
+        {
+            var offering = await _craftRepository.GetCraftOfferingByIdAsync(craftOfferingId) ?? throw new InvalidOperationException();
+            var masterProfileId = offering.Craft.MasterProfileCrafts.First().MasterProfileId;
+
+            var apprenticeship = new Apprenticeship
+            {
+                ApprenticeProfileId = apprenticeProfileId,
+                MasterProfileId = masterProfileId,
+                CraftOfferingId = craftOfferingId,
+                Status = ApprenticeshipStatus.Pending.ToString()
+            };
+
+            await _apprenticeRepository.AddApprenticeshipAsync(apprenticeship);
+        }
+
+        public Task<List<Apprenticeship>> GetApprenticeshipsAsync(int apprenticeProfileId)
+        {
+            return _apprenticeRepository.GetApprenticeshipsAsync(apprenticeProfileId);
+        }
+    }
+}

--- a/smelite_app/smelite_app/Services/IApprenticeService.cs
+++ b/smelite_app/smelite_app/Services/IApprenticeService.cs
@@ -1,0 +1,15 @@
+using smelite_app.Models;
+using smelite_app.ViewModels.Apprentice;
+
+namespace smelite_app.Services
+{
+    public interface IApprenticeService
+    {
+        Task<ApprenticeProfileViewModel?> GetProfileAsync(string userId);
+        Task<ApprenticeProfile?> GetByUserIdAsync(string userId);
+        Task UpdateProfileAsync(ApprenticeProfile profile);
+
+        Task AddApprenticeshipAsync(int apprenticeProfileId, int craftOfferingId);
+        Task<List<Apprenticeship>> GetApprenticeshipsAsync(int apprenticeProfileId);
+    }
+}

--- a/smelite_app/smelite_app/ViewModels/Apprentice/ApprenticeProfileViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Apprentice/ApprenticeProfileViewModel.cs
@@ -1,0 +1,11 @@
+namespace smelite_app.ViewModels.Apprentice
+{
+    public class ApprenticeProfileViewModel
+    {
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string? ProfileImageUrl { get; set; }
+        public string? PersonalInformation { get; set; }
+    }
+}

--- a/smelite_app/smelite_app/ViewModels/Apprentice/EditApprenticeProfileViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Apprentice/EditApprenticeProfileViewModel.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+
+namespace smelite_app.ViewModels.Apprentice
+{
+    public class EditApprenticeProfileViewModel
+    {
+        [Required]
+        [MaxLength(100)]
+        public string FirstName { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(100)]
+        public string LastName { get; set; } = string.Empty;
+
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [MaxLength(300)]
+        public string? ProfileImageUrl { get; set; }
+
+        public IFormFile? ProfileImage { get; set; }
+
+        [MaxLength(2000)]
+        public string? PersonalInformation { get; set; }
+
+        [DataType(DataType.Password)]
+        public string? CurrentPassword { get; set; }
+
+        [DataType(DataType.Password)]
+        public string? NewPassword { get; set; }
+
+        [DataType(DataType.Password)]
+        [Compare("NewPassword")]
+        public string? ConfirmPassword { get; set; }
+    }
+}

--- a/smelite_app/smelite_app/Views/Apprentice/CreateCraft.cshtml
+++ b/smelite_app/smelite_app/Views/Apprentice/CreateCraft.cshtml
@@ -1,1 +1,0 @@
-<h2>Create Craft</h2>

--- a/smelite_app/smelite_app/Views/Apprentice/EditProfile.cshtml
+++ b/smelite_app/smelite_app/Views/Apprentice/EditProfile.cshtml
@@ -1,0 +1,74 @@
+@model smelite_app.ViewModels.Apprentice.EditApprenticeProfileViewModel
+
+<h2>Edit Profile</h2>
+
+<form asp-action="EditProfile" method="post" enctype="multipart/form-data">
+    <div>
+        <label asp-for="FirstName"></label>
+        <input asp-for="FirstName" maxlength="100" required />
+    </div>
+    <div>
+        <label asp-for="LastName"></label>
+        <input asp-for="LastName" maxlength="100" required />
+    </div>
+    <div>
+        <label asp-for="Email"></label>
+        <input asp-for="Email" type="email" required />
+    </div>
+    <div class="mb-3">
+        <label>Profile Image</label>
+        <div id="drop-zone" class="border border-secondary p-3 text-center">
+            <img id="preview" src="@Model.ProfileImageUrl" class="img-fluid mb-2" style="max-height:200px;" />
+            <p>Drag & drop image here or click to select</p>
+            <input type="file" asp-for="ProfileImage" class="form-control" style="display:none" id="fileInput" />
+        </div>
+    </div>
+    <div>
+        <label asp-for="PersonalInformation"></label>
+        <textarea asp-for="PersonalInformation" maxlength="2000"></textarea>
+    </div>
+    <div>
+        <label asp-for="CurrentPassword"></label>
+        <input asp-for="CurrentPassword" />
+    </div>
+    <div>
+        <label asp-for="NewPassword"></label>
+        <input asp-for="NewPassword" />
+    </div>
+    <div>
+        <label asp-for="ConfirmPassword"></label>
+        <input asp-for="ConfirmPassword" />
+    </div>
+    <button type="submit">Save</button>
+</form>
+
+@section Scripts {
+    <script>
+        const dropZone = document.getElementById('drop-zone');
+        const fileInput = document.getElementById('fileInput');
+        const preview = document.getElementById('preview');
+
+        dropZone.addEventListener('click', () => fileInput.click());
+        dropZone.addEventListener('dragover', e => {
+            e.preventDefault();
+            dropZone.classList.add('bg-secondary');
+        });
+        dropZone.addEventListener('dragleave', () => dropZone.classList.remove('bg-secondary'));
+        dropZone.addEventListener('drop', e => {
+            e.preventDefault();
+            dropZone.classList.remove('bg-secondary');
+            fileInput.files = e.dataTransfer.files;
+            updatePreview();
+        });
+        fileInput.addEventListener('change', updatePreview);
+
+        function updatePreview() {
+            const file = fileInput.files[0];
+            if (file) {
+                const reader = new FileReader();
+                reader.onload = e => preview.src = e.target.result;
+                reader.readAsDataURL(file);
+            }
+        }
+    </script>
+}

--- a/smelite_app/smelite_app/Views/Apprentice/Profile.cshtml
+++ b/smelite_app/smelite_app/Views/Apprentice/Profile.cshtml
@@ -1,1 +1,14 @@
+@model smelite_app.ViewModels.Apprentice.ApprenticeProfileViewModel
+
 <h2>Apprentice Profile</h2>
+
+<div class="mb-3">
+    <p>Name: @Model.FirstName @Model.LastName</p>
+    <p>Email: @Model.Email</p>
+    <p>Info: @Model.PersonalInformation</p>
+</div>
+
+<div class="btn-group" role="group">
+    <a asp-action="EditProfile" class="btn btn-primary">Edit Profile</a>
+    <a asp-action="Sessions" class="btn btn-primary">Apprenticeships</a>
+</div>

--- a/smelite_app/smelite_app/Views/Apprentice/Sessions.cshtml
+++ b/smelite_app/smelite_app/Views/Apprentice/Sessions.cshtml
@@ -1,1 +1,10 @@
-<h2>Apprentice Sessions</h2>
+@model IEnumerable<smelite_app.Models.Apprenticeship>
+
+<h2>Apprenticeships</h2>
+
+<ul>
+@foreach (var a in Model)
+{
+    <li>@a.MasterProfile.ApplicationUser.FirstName @a.MasterProfile.ApplicationUser.LastName - @a.CraftOffering.Craft.Name - @a.Status</li>
+}
+</ul>

--- a/smelite_app/smelite_app/Views/Crafts/Details.cshtml
+++ b/smelite_app/smelite_app/Views/Crafts/Details.cshtml
@@ -16,6 +16,7 @@
             <th>Location</th>
             <th>Package</th>
             <th>Price</th>
+            <th></th>
         </tr>
     </thead>
     <tbody>
@@ -25,6 +26,15 @@
             <td>@o.Location</td>
             <td>@o.Package</td>
             <td>@o.Price</td>
+            <td>
+                @if (User.IsInRole("Apprentice"))
+                {
+                    <form asp-controller="Apprentice" asp-action="Order" method="post">
+                        <input type="hidden" name="offeringId" value="@o.Id" />
+                        <button type="submit" class="btn btn-sm btn-primary">Order</button>
+                    </form>
+                }
+            </td>
         </tr>
     }
     </tbody>


### PR DESCRIPTION
## Summary
- implement apprentice profile services and repository methods
- add editing and sessions features for apprentices
- enable ordering craft offerings from details page
- wire up new apprentice service in program configuration
- add views for apprentice profile management

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68724c4399248330b1419e2c2de1880c