### PR TITLE
Add antiforgery validation to account forms

### DIFF
--- a/smelite_app/smelite_app/Controllers/AccountController.cs
+++ b/smelite_app/smelite_app/Controllers/AccountController.cs
@@ -22,6 +22,7 @@ namespace smelite_app.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Register(RegisterViewModel model)
         {
             if (!ModelState.IsValid) return View(model);
@@ -45,6 +46,7 @@ namespace smelite_app.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Login(LoginViewModel model)
         {
             if (!ModelState.IsValid) return View(model);

--- a/smelite_app/smelite_app/Views/Account/Login.cshtml
+++ b/smelite_app/smelite_app/Views/Account/Login.cshtml
@@ -1,6 +1,6 @@
 @model smelite_app.ViewModels.Account.LoginViewModel
 
-<form asp-action="Login" method="post">
+<form asp-action="Login" method="post" asp-antiforgery="true">
     <div>
         <label asp-for="Email"></label>
         <input asp-for="Email" />

--- a/smelite_app/smelite_app/Views/Account/Register.cshtml
+++ b/smelite_app/smelite_app/Views/Account/Register.cshtml
@@ -1,6 +1,6 @@
 @model smelite_app.ViewModels.Account.RegisterViewModel
 
-<form asp-action="Register" method="post">
+<form asp-action="Register" method="post" asp-antiforgery="true">
     <div>
         <label asp-for="Email"></label>
         <input asp-for="Email" />


### PR DESCRIPTION
## Summary
- enforce antiforgery validation for Register and Login actions
- explicitly enable antiforgery token in Register and Login forms

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873987d45f083308bea1e47afe67afa