### PR TITLE
Add unit/integration test project

### DIFF
--- a/smelite_app/smelite_app.Tests/IntegrationTests/ApprenticeControllerTests.cs
+++ b/smelite_app/smelite_app.Tests/IntegrationTests/ApprenticeControllerTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using smelite_app.Controllers;
+using smelite_app.Models;
+using smelite_app.Repositories;
+using smelite_app.Services;
+using Xunit;
+
+namespace smelite_app.Tests.IntegrationTests
+{
+    public class ApprenticeControllerTests
+    {
+        [Fact]
+        public async Task Order_PersistsApprenticeship()
+        {
+            using var context = TestHelper.GetInMemoryDbContext();
+            var apprenticeProfile = new ApprenticeProfile { Id = 1, ApplicationUserId = "u2" };
+            var masterProfile = new MasterProfile { Id = 2, ApplicationUserId = "u1" };
+            var offering = new CraftOffering { Id = 3, Craft = new Craft { MasterProfileCrafts = new List<MasterProfileCraft>{ new MasterProfileCraft{ MasterProfileId = 2 } } } };
+            context.ApprenticeProfiles.Add(apprenticeProfile);
+            context.MasterProfiles.Add(masterProfile);
+            context.CraftOfferings.Add(offering);
+            await context.SaveChangesAsync();
+
+            var appRepo = new ApprenticeRepository(context);
+            var craftRepo = new CraftRepository(context);
+            var service = new ApprenticeService(appRepo, craftRepo);
+
+            var user = new ApplicationUser { Id = "u2", Email = "e" };
+            var userMgr = TestHelper.GetMockUserManager(user);
+            var env = new Mock<IWebHostEnvironment>();
+
+            var controller = new ApprenticeController(service, userMgr, env.Object)
+            {
+                ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+            };
+
+            var result = await controller.Order(3);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal(1, context.Apprenticeships.Count());
+            var appr = context.Apprenticeships.Single();
+            Assert.Equal(1, appr.ApprenticeProfileId);
+            Assert.Equal(2, appr.MasterProfileId);
+        }
+
+        [Fact]
+        public async Task Order_NoProfile_ReturnsNotFound()
+        {
+            using var context = TestHelper.GetInMemoryDbContext();
+            var user = new ApplicationUser { Id = "u3" };
+            var userMgr = TestHelper.GetMockUserManager(user);
+            var appRepo = new ApprenticeRepository(context);
+            var craftRepo = new CraftRepository(context);
+            var service = new ApprenticeService(appRepo, craftRepo);
+            var env = new Mock<IWebHostEnvironment>();
+            var controller = new ApprenticeController(service, userMgr, env.Object)
+            {
+                ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+            };
+
+            var result = await controller.Order(1);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/smelite_app/smelite_app.Tests/IntegrationTests/CraftSoftDeleteTests.cs
+++ b/smelite_app/smelite_app.Tests/IntegrationTests/CraftSoftDeleteTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using smelite_app.Repositories;
+using smelite_app.Services;
+using smelite_app.Models;
+using Xunit;
+
+namespace smelite_app.Tests.IntegrationTests
+{
+    public class CraftSoftDeleteTests
+    {
+        [Fact]
+        public async Task SoftDeleteCraft_SetsFlagAndExcludedFromQueries()
+        {
+            using var context = TestHelper.GetInMemoryDbContext();
+            context.CraftTypes.Add(new CraftType { Id = 1, Name = "Type" });
+            var craft = new Craft { Id = 1, Name = "Craft", CraftTypeId=1 };
+            context.Crafts.Add(craft);
+            await context.SaveChangesAsync();
+
+            var repo = new CraftRepository(context);
+            var service = new CraftService(repo);
+
+            await service.SoftDeleteCraftAsync(1);
+
+            var stored = context.Crafts.IgnoreQueryFilters().Single(c => c.Id==1);
+            Assert.True(stored.IsDeleted);
+            Assert.Null(await service.GetCraftByIdAsync(1));
+        }
+    }
+}

--- a/smelite_app/smelite_app.Tests/IntegrationTests/MasterControllerTests.cs
+++ b/smelite_app/smelite_app.Tests/IntegrationTests/MasterControllerTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using smelite_app.Controllers;
+using smelite_app.Data;
+using smelite_app.Models;
+using smelite_app.Repositories;
+using smelite_app.Services;
+using smelite_app.ViewModels.Master;
+using Xunit;
+
+namespace smelite_app.Tests.IntegrationTests
+{
+    public class MasterControllerTests
+    {
+        [Fact]
+        public async Task CreateCraft_PersistsCraft()
+        {
+            using var context = TestHelper.GetInMemoryDbContext();
+            context.CraftTypes.Add(new CraftType { Id = 1, Name = "Type" });
+            var masterProfile = new MasterProfile { Id = 1, ApplicationUserId = "u1" };
+            context.MasterProfiles.Add(masterProfile);
+            await context.SaveChangesAsync();
+
+            var masterRepo = new MasterRepository(context);
+            var craftRepo = new CraftRepository(context);
+            var masterService = new MasterService(masterRepo);
+            var craftService = new CraftService(craftRepo);
+
+            var user = new ApplicationUser { Id = "u1", Email = "e" };
+            var userMgr = TestHelper.GetMockUserManager(user);
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.SetupGet(e => e.WebRootPath).Returns("/tmp");
+
+            var controller = new MasterController(masterService, userMgr, craftService, env.Object)
+            {
+                ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+            };
+            var vm = new CraftViewModel
+            {
+                Name = "Craft",
+                CraftDescription = "desc",
+                ExperienceYears = 1,
+                CraftTypeId = 1,
+                Offerings = new List<CraftOfferingFormViewModel>()
+            };
+
+            var result = await controller.CreateCraft(vm);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal(1, context.Crafts.Count());
+            Assert.Equal("Craft", context.Crafts.Single().Name);
+        }
+
+        [Fact]
+        public async Task CreateCraft_NoProfile_ReturnsNotFound()
+        {
+            using var context = TestHelper.GetInMemoryDbContext();
+            context.CraftTypes.Add(new CraftType { Id = 1, Name = "Type" });
+            await context.SaveChangesAsync();
+
+            var masterRepo = new MasterRepository(context);
+            var craftRepo = new CraftRepository(context);
+            var masterService = new MasterService(masterRepo);
+            var craftService = new CraftService(craftRepo);
+
+            var user = new ApplicationUser { Id = "u1", Email = "e" };
+            var userMgr = TestHelper.GetMockUserManager(user);
+            var env = new Mock<IWebHostEnvironment>();
+            env.SetupGet(e => e.WebRootPath).Returns("/tmp");
+
+            var controller = new MasterController(masterService, userMgr, craftService, env.Object)
+            {
+                ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+            };
+            var vm = new CraftViewModel { Name = "Craft", CraftDescription="d", ExperienceYears=1, CraftTypeId=1, Offerings=new List<CraftOfferingFormViewModel>() };
+
+            var result = await controller.CreateCraft(vm);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/smelite_app/smelite_app.Tests/TestHelper.cs
+++ b/smelite_app/smelite_app.Tests/TestHelper.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using smelite_app.Data;
+using smelite_app.Models;
+
+namespace smelite_app.Tests
+{
+    public static class TestHelper
+    {
+        public static ApplicationDbContext GetInMemoryDbContext()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new ApplicationDbContext(options);
+        }
+
+        public static UserManager<ApplicationUser> GetMockUserManager(ApplicationUser? user)
+        {
+            var store = new Mock<IUserStore<ApplicationUser>>();
+            var mgr = new Mock<UserManager<ApplicationUser>>(store.Object, null, null, null, null, null, null, null, null);
+            mgr.Setup(m => m.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user!);
+            mgr.Setup(m => m.FindByEmailAsync(It.IsAny<string>())).ReturnsAsync((string email) => user?.Email == email ? user : null);
+            mgr.Setup(m => m.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            mgr.Setup(m => m.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            mgr.Setup(m => m.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            mgr.Setup(m => m.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync("token");
+            mgr.Setup(m => m.UpdateAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(IdentityResult.Success);
+            return mgr.Object;
+        }
+    }
+}

--- a/smelite_app/smelite_app.Tests/UnitTests/AccountServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/AccountServiceTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Moq;
+using smelite_app.Models;
+using smelite_app.Repositories;
+using smelite_app.Services;
+using smelite_app.ViewModels.Account;
+using Xunit;
+
+namespace smelite_app.Tests.UnitTests
+{
+    public class AccountServiceTests
+    {
+        private AccountService CreateService(out Mock<UserManager<ApplicationUser>> userMgrMock,
+                                             out Mock<SignInManager<ApplicationUser>> signInMgrMock,
+                                             out Mock<IMasterRepository> masterRepo,
+                                             out Mock<IApprenticeRepository> apprenticeRepo)
+        {
+            userMgrMock = new Mock<UserManager<ApplicationUser>>(Mock.Of<IUserStore<ApplicationUser>>(), null, null, null, null, null, null, null, null);
+            signInMgrMock = new Mock<SignInManager<ApplicationUser>>(userMgrMock.Object, Mock.Of<IHttpContextAccessor>(), Mock.Of<IUserClaimsPrincipalFactory<ApplicationUser>>(), null, null, null, null);
+            masterRepo = new Mock<IMasterRepository>();
+            apprenticeRepo = new Mock<IApprenticeRepository>();
+            var logger = new Mock<ILogger<MasterRepository>>();
+            return new AccountService(userMgrMock.Object, signInMgrMock.Object, masterRepo.Object, apprenticeRepo.Object, logger.Object);
+        }
+
+        [Fact]
+        public async Task Login_UserNotFound_ReturnsFailed()
+        {
+            var service = CreateService(out var userMgr, out var signInMgr, out _, out _);
+            userMgr.Setup(m => m.FindByEmailAsync("email"))!.ReturnsAsync((ApplicationUser?)null);
+
+            var result = await service.LoginAsync(new LoginViewModel { Email = "email", Password = "pwd" });
+
+            Assert.False(result.Succeeded);
+            signInMgr.Verify(m => m.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), false, false), Times.Never);
+        }
+
+        [Fact]
+        public async Task Login_ValidUser_ReturnsSuccess()
+        {
+            var service = CreateService(out var userMgr, out var signInMgr, out _, out _);
+            var user = new ApplicationUser { Email = "email" };
+            userMgr.Setup(m => m.FindByEmailAsync("email"))!.ReturnsAsync(user);
+            signInMgr.Setup(m => m.PasswordSignInAsync("email", "pwd", false, false)).ReturnsAsync(SignInResult.Success);
+
+            var result = await service.LoginAsync(new LoginViewModel { Email = "email", Password = "pwd" });
+
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Register_UserExists_ReturnsFailed()
+        {
+            var service = CreateService(out var userMgr, out _, out _, out _);
+            userMgr.Setup(m => m.FindByEmailAsync("e"))!.ReturnsAsync(new ApplicationUser());
+
+            var result = await service.RegisterAsync(new RegisterViewModel { Email = "e" });
+
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Register_MasterRole_AddsMasterProfile()
+        {
+            var service = CreateService(out var userMgr, out _, out var masterRepo, out var appRepo);
+            userMgr.Setup(m => m.FindByEmailAsync("e"))!.ReturnsAsync((ApplicationUser?)null);
+            userMgr.Setup(m => m.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+
+            var vm = new RegisterViewModel { Email = "e", Password = "p", FirstName="f", LastName="l", Role="Master" };
+            var result = await service.RegisterAsync(vm);
+
+            Assert.True(result.Succeeded);
+            masterRepo.Verify(m => m.AddProfileAsync(It.IsAny<MasterProfile>()), Times.Once);
+            appRepo.Verify(m => m.AddProfileAsync(It.IsAny<ApprenticeProfile>()), Times.Never);
+        }
+    }
+}

--- a/smelite_app/smelite_app.Tests/UnitTests/ApprenticeServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/ApprenticeServiceTests.cs
@@ -1,0 +1,36 @@
+using Moq;
+using smelite_app.Enums;
+using smelite_app.Models;
+using smelite_app.Repositories;
+using smelite_app.Services;
+using Xunit;
+
+namespace smelite_app.Tests.UnitTests
+{
+    public class ApprenticeServiceTests
+    {
+        [Fact]
+        public async Task AddApprenticeship_Valid_AddsApprenticeship()
+        {
+            var appRepo = new Mock<IApprenticeRepository>();
+            var craftRepo = new Mock<ICraftRepository>();
+            craftRepo.Setup(r => r.GetCraftOfferingByIdAsync(1)).ReturnsAsync(new CraftOffering { Id = 1, Craft = new Craft { MasterProfileCrafts = new List<MasterProfileCraft>{ new MasterProfileCraft{ MasterProfileId=5 } } } });
+            var service = new ApprenticeService(appRepo.Object, craftRepo.Object);
+
+            await service.AddApprenticeshipAsync(2, 1);
+
+            appRepo.Verify(r => r.AddApprenticeshipAsync(It.Is<Apprenticeship>(a => a.ApprenticeProfileId==2 && a.CraftOfferingId==1 && a.MasterProfileId==5 && a.Status==ApprenticeshipStatus.Pending.ToString())), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddApprenticeship_InvalidOffering_Throws()
+        {
+            var appRepo = new Mock<IApprenticeRepository>();
+            var craftRepo = new Mock<ICraftRepository>();
+            craftRepo.Setup(r => r.GetCraftOfferingByIdAsync(1)).ReturnsAsync((CraftOffering?)null);
+            var service = new ApprenticeService(appRepo.Object, craftRepo.Object);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => service.AddApprenticeshipAsync(1,1));
+        }
+    }
+}

--- a/smelite_app/smelite_app.Tests/UnitTests/CraftServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/CraftServiceTests.cs
@@ -1,0 +1,35 @@
+using Moq;
+using smelite_app.Repositories;
+using smelite_app.Services;
+using smelite_app.Models;
+using Xunit;
+
+namespace smelite_app.Tests.UnitTests
+{
+    public class CraftServiceTests
+    {
+        [Fact]
+        public async Task SoftDeleteCraft_CallsRepository()
+        {
+            var repo = new Mock<ICraftRepository>();
+            var service = new CraftService(repo.Object);
+
+            await service.SoftDeleteCraftAsync(5);
+
+            repo.Verify(r => r.SoftDeleteCraftAsync(5), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetCraftById_ReturnsFromRepository()
+        {
+            var repo = new Mock<ICraftRepository>();
+            var craft = new Craft { Id = 3 };
+            repo.Setup(r => r.GetCraftByIdAsync(3)).ReturnsAsync(craft);
+            var service = new CraftService(repo.Object);
+
+            var result = await service.GetCraftByIdAsync(3);
+
+            Assert.Equal(craft, result);
+        }
+    }
+}

--- a/smelite_app/smelite_app.Tests/UnitTests/MasterServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/MasterServiceTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Hosting;
+using Moq;
+using smelite_app.Models;
+using smelite_app.Repositories;
+using smelite_app.Services;
+using smelite_app.ViewModels.Master;
+using Xunit;
+
+namespace smelite_app.Tests.UnitTests
+{
+    public class MasterServiceTests
+    {
+        [Fact]
+        public async Task GetProfile_ReturnsViewModel()
+        {
+            var repo = new Mock<IMasterRepository>();
+            var profile = new MasterProfile
+            {
+                ApplicationUser = new ApplicationUser { FirstName = "f", LastName = "l", Email = "e", ProfileImageUrl = "p" },
+                PersonalInformation = "pi"
+            };
+            repo.Setup(r => r.GetByUserIdAsync("1")).ReturnsAsync(profile);
+            var service = new MasterService(repo.Object);
+
+            var result = await service.GetProfileAsync("1");
+
+            Assert.NotNull(result);
+            Assert.Equal("f", result!.FirstName);
+        }
+
+        [Fact]
+        public async Task AddCraft_CallsRepository()
+        {
+            var repo = new Mock<IMasterRepository>();
+            var env = new Mock<IWebHostEnvironment>();
+            var service = new MasterService(repo.Object);
+            var vm = new CraftViewModel { Name = "n", CraftDescription="d", ExperienceYears=1, CraftTypeId=1, Offerings=new List<CraftOfferingFormViewModel>() };
+
+            await service.AddCraftAsync(2, vm, "root", "user");
+
+            repo.Verify(r => r.AddCraftAsync(2, It.IsAny<Craft>(), It.IsAny<IEnumerable<CraftOffering>>(), It.IsAny<IEnumerable<CraftImage>>()), Times.Once);
+        }
+    }
+}

--- a/smelite_app/smelite_app.Tests/smelite_app.Tests.csproj
+++ b/smelite_app/smelite_app.Tests/smelite_app.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.5.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="Moq" Version="4.20.139" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../smelite_app/smelite_app.csproj" />
+  </ItemGroup>
+</Project>

--- a/smelite_app/smelite_app.sln
+++ b/smelite_app/smelite_app.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.12.35514.174 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "smelite_app", "smelite_app\smelite_app.csproj", "{29B2986A-204F-4C96-8AEB-C7CFB0F21AB2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "smelite_app.Tests", "smelite_app.Tests\smelite_app.Tests.csproj", "{FC8D9AF9-6470-40B9-A1C3-B989BDEED1C2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +16,12 @@ Global
 		{29B2986A-204F-4C96-8AEB-C7CFB0F21AB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{29B2986A-204F-4C96-8AEB-C7CFB0F21AB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29B2986A-204F-4C96-8AEB-C7CFB0F21AB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{29B2986A-204F-4C96-8AEB-C7CFB0F21AB2}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+               {29B2986A-204F-4C96-8AEB-C7CFB0F21AB2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {FC8D9AF9-6470-40B9-A1C3-B989BDEED1C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {FC8D9AF9-6470-40B9-A1C3-B989BDEED1C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {FC8D9AF9-6470-40B9-A1C3-B989BDEED1C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {FC8D9AF9-6470-40B9-A1C3-B989BDEED1C2}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add new xUnit test project `smelite_app.Tests`
- write unit tests for services using Moq
- create integration tests with in-memory EF Core context
- update solution file to include new test project

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873988609a48330ad69b9a22aa4647c