### PR TITLE
Fix image and craft offering deletions

### DIFF
--- a/smelite_app/smelite_app/Controllers/MasterController.cs
+++ b/smelite_app/smelite_app/Controllers/MasterController.cs
@@ -287,6 +287,15 @@ namespace smelite_app.Controllers
             if (image == null || !image.Craft.MasterProfileCrafts.Any(m => m.MasterProfileId == profile.Id))
                 return NotFound();
 
+            if (!string.IsNullOrEmpty(image.ImageUrl) && !image.ImageUrl.Equals(Variables.defaultCraftImageUrl, StringComparison.OrdinalIgnoreCase))
+            {
+                var path = Path.Combine(_environment.WebRootPath, image.ImageUrl.TrimStart('/'));
+                if (System.IO.File.Exists(path))
+                {
+                    System.IO.File.Delete(path);
+                }
+            }
+
             await _craftService.RemoveCraftImageAsync(id);
             return RedirectToAction(nameof(EditCraft), new { id = image.CraftId });
         }

--- a/smelite_app/smelite_app/Repositories/CraftRepository.cs
+++ b/smelite_app/smelite_app/Repositories/CraftRepository.cs
@@ -108,10 +108,25 @@ namespace smelite_app.Repositories
 
         public async Task SoftDeleteCraftOfferingAsync(int offeringId)
         {
-            var offering = await _context.CraftOfferings.FindAsync(offeringId);
+            var offering = await _context.CraftOfferings
+                .Include(o => o.CraftLocation)
+                .Include(o => o.CraftPackage)
+                .FirstOrDefaultAsync(o => o.Id == offeringId);
+
             if (offering != null)
             {
                 offering.IsDeleted = true;
+
+                if (offering.CraftLocation != null)
+                {
+                    _context.CraftLocations.Remove(offering.CraftLocation);
+                }
+
+                if (offering.CraftPackage != null)
+                {
+                    _context.CraftPackages.Remove(offering.CraftPackage);
+                }
+
                 await _context.SaveChangesAsync();
             }
         }


### PR DESCRIPTION
## Summary
- remove associated package and location when deleting an offering
- delete physical craft image file when master removes an image

## Testing
- `dotnet test smelite_app/smelite_app.Tests/smelite_app.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873bc93c0d48330a749c7655aea9830