### PR TITLE
Implement login block for deactivated users

### DIFF
--- a/smelite_app/smelite_app.Tests/UnitTests/AccountServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/AccountServiceTests.cs
@@ -50,6 +50,34 @@ namespace smelite_app.Tests.UnitTests
         }
 
         [Fact]
+        public async Task Login_InactiveApprentice_ReturnsNotAllowed()
+        {
+            var service = CreateService(out var userMgr, out var signInMgr, out _, out var appRepo);
+            var user = new ApplicationUser { Id = "u1", Email = "email", Role = "Apprentice" };
+            userMgr.Setup(m => m.FindByEmailAsync("email"))!.ReturnsAsync(user);
+            appRepo.Setup(r => r.GetByUserIdAsync("u1"))!.ReturnsAsync(new ApprenticeProfile { IsActive = false });
+
+            var result = await service.LoginAsync(new LoginViewModel { Email = "email", Password = "pwd" });
+
+            Assert.False(result.Succeeded);
+            signInMgr.Verify(m => m.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), false, false), Times.Never);
+        }
+
+        [Fact]
+        public async Task Login_InactiveMaster_ReturnsNotAllowed()
+        {
+            var service = CreateService(out var userMgr, out var signInMgr, out var masterRepo, out _);
+            var user = new ApplicationUser { Id = "u1", Email = "email", Role = "Master" };
+            userMgr.Setup(m => m.FindByEmailAsync("email"))!.ReturnsAsync(user);
+            masterRepo.Setup(r => r.GetByUserIdAsync("u1"))!.ReturnsAsync(new MasterProfile { IsActive = false });
+
+            var result = await service.LoginAsync(new LoginViewModel { Email = "email", Password = "pwd" });
+
+            Assert.False(result.Succeeded);
+            signInMgr.Verify(m => m.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), false, false), Times.Never);
+        }
+
+        [Fact]
         public async Task Register_UserExists_ReturnsFailed()
         {
             var service = CreateService(out var userMgr, out _, out _, out _);

--- a/smelite_app/smelite_app/Services/AccountService.cs
+++ b/smelite_app/smelite_app/Services/AccountService.cs
@@ -38,6 +38,28 @@ namespace smelite_app.Services
                 return SignInResult.Failed;
             }
 
+            if (user.Role != "Admin")
+            {
+                bool isActive = true;
+
+                if (user.Role == "Master")
+                {
+                    var profile = await _masterRepo.GetByUserIdAsync(user.Id);
+                    isActive = profile?.IsActive ?? false;
+                }
+                else if (user.Role == "Apprentice")
+                {
+                    var profile = await _apprenticeRepo.GetByUserIdAsync(user.Id);
+                    isActive = profile?.IsActive ?? false;
+                }
+
+                if (!isActive)
+                {
+                    _logger.LogWarning("Login attempt for deactivated user {Email}", model.Email);
+                    return SignInResult.NotAllowed;
+                }
+            }
+
             var result = await _signInManager.PasswordSignInAsync(model.Email, model.Password, false, false);
 
             if (result.Succeeded)


### PR DESCRIPTION
## Summary
- block login if user's profile is deactivated
- add unit tests covering inactive logins

## Testing
- `dotnet test smelite_app/smelite_app.Tests/smelite_app.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874df25bf908330bc8b0e22559b6988