### PR TITLE
Enable auto login after registration

### DIFF
--- a/smelite_app/smelite_app.Tests/UnitTests/AccountServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/AccountServiceTests.cs
@@ -11,38 +11,36 @@ namespace smelite_app.Tests.UnitTests
 {
     public class AccountServiceTests
     {
-        private AccountService CreateService(out Mock<UserManager<ApplicationUser>> userMgrMock,
-                                             out Mock<SignInManager<ApplicationUser>> signInMgrMock,
+        private AccountService CreateService(out Mock<IAccountRepository> accountRepo,
                                              out Mock<IMasterRepository> masterRepo,
                                              out Mock<IApprenticeRepository> apprenticeRepo)
         {
-            userMgrMock = new Mock<UserManager<ApplicationUser>>(Mock.Of<IUserStore<ApplicationUser>>(), null, null, null, null, null, null, null, null);
-            signInMgrMock = new Mock<SignInManager<ApplicationUser>>(userMgrMock.Object, Mock.Of<IHttpContextAccessor>(), Mock.Of<IUserClaimsPrincipalFactory<ApplicationUser>>(), null, null, null, null);
+            accountRepo = new Mock<IAccountRepository>();
             masterRepo = new Mock<IMasterRepository>();
             apprenticeRepo = new Mock<IApprenticeRepository>();
             var logger = new Mock<ILogger<MasterRepository>>();
-            return new AccountService(userMgrMock.Object, signInMgrMock.Object, masterRepo.Object, apprenticeRepo.Object, logger.Object);
+            return new AccountService(accountRepo.Object, masterRepo.Object, apprenticeRepo.Object, logger.Object);
         }
 
         [Fact]
         public async Task Login_UserNotFound_ReturnsFailed()
         {
-            var service = CreateService(out var userMgr, out var signInMgr, out _, out _);
-            userMgr.Setup(m => m.FindByEmailAsync("email"))!.ReturnsAsync((ApplicationUser?)null);
+            var service = CreateService(out var accountRepo, out _, out _);
+            accountRepo.Setup(r => r.FindByEmailAsync("email"))!.ReturnsAsync((ApplicationUser?)null);
 
             var result = await service.LoginAsync(new LoginViewModel { Email = "email", Password = "pwd" });
 
             Assert.False(result.Succeeded);
-            signInMgr.Verify(m => m.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), false, false), Times.Never);
+            accountRepo.Verify(m => m.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), false, false), Times.Never);
         }
 
         [Fact]
         public async Task Login_ValidUser_ReturnsSuccess()
         {
-            var service = CreateService(out var userMgr, out var signInMgr, out _, out _);
+            var service = CreateService(out var accountRepo, out _, out _);
             var user = new ApplicationUser { Email = "email" };
-            userMgr.Setup(m => m.FindByEmailAsync("email"))!.ReturnsAsync(user);
-            signInMgr.Setup(m => m.PasswordSignInAsync("email", "pwd", false, false)).ReturnsAsync(SignInResult.Success);
+            accountRepo.Setup(r => r.FindByEmailAsync("email"))!.ReturnsAsync(user);
+            accountRepo.Setup(r => r.PasswordSignInAsync("email", "pwd", false, false)).ReturnsAsync(SignInResult.Success);
 
             var result = await service.LoginAsync(new LoginViewModel { Email = "email", Password = "pwd" });
 
@@ -52,36 +50,36 @@ namespace smelite_app.Tests.UnitTests
         [Fact]
         public async Task Login_InactiveApprentice_ReturnsNotAllowed()
         {
-            var service = CreateService(out var userMgr, out var signInMgr, out _, out var appRepo);
+            var service = CreateService(out var accountRepo, out _, out var appRepo);
             var user = new ApplicationUser { Id = "u1", Email = "email", Role = "Apprentice" };
-            userMgr.Setup(m => m.FindByEmailAsync("email"))!.ReturnsAsync(user);
+            accountRepo.Setup(r => r.FindByEmailAsync("email"))!.ReturnsAsync(user);
             appRepo.Setup(r => r.GetByUserIdAsync("u1"))!.ReturnsAsync(new ApprenticeProfile { IsActive = false });
 
             var result = await service.LoginAsync(new LoginViewModel { Email = "email", Password = "pwd" });
 
             Assert.False(result.Succeeded);
-            signInMgr.Verify(m => m.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), false, false), Times.Never);
+            accountRepo.Verify(m => m.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), false, false), Times.Never);
         }
 
         [Fact]
         public async Task Login_InactiveMaster_ReturnsNotAllowed()
         {
-            var service = CreateService(out var userMgr, out var signInMgr, out var masterRepo, out _);
+            var service = CreateService(out var accountRepo, out var masterRepo, out _);
             var user = new ApplicationUser { Id = "u1", Email = "email", Role = "Master" };
-            userMgr.Setup(m => m.FindByEmailAsync("email"))!.ReturnsAsync(user);
+            accountRepo.Setup(r => r.FindByEmailAsync("email"))!.ReturnsAsync(user);
             masterRepo.Setup(r => r.GetByUserIdAsync("u1"))!.ReturnsAsync(new MasterProfile { IsActive = false });
 
             var result = await service.LoginAsync(new LoginViewModel { Email = "email", Password = "pwd" });
 
             Assert.False(result.Succeeded);
-            signInMgr.Verify(m => m.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), false, false), Times.Never);
+            accountRepo.Verify(m => m.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), false, false), Times.Never);
         }
 
         [Fact]
         public async Task Register_UserExists_ReturnsFailed()
         {
-            var service = CreateService(out var userMgr, out _, out _, out _);
-            userMgr.Setup(m => m.FindByEmailAsync("e"))!.ReturnsAsync(new ApplicationUser());
+            var service = CreateService(out var accountRepo, out _, out _);
+            accountRepo.Setup(r => r.FindByEmailAsync("e"))!.ReturnsAsync(new ApplicationUser());
 
             var result = await service.RegisterAsync(new RegisterViewModel { Email = "e" });
 
@@ -91,9 +89,9 @@ namespace smelite_app.Tests.UnitTests
         [Fact]
         public async Task Register_MasterRole_AddsMasterProfile()
         {
-            var service = CreateService(out var userMgr, out _, out var masterRepo, out var appRepo);
-            userMgr.Setup(m => m.FindByEmailAsync("e"))!.ReturnsAsync((ApplicationUser?)null);
-            userMgr.Setup(m => m.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            var service = CreateService(out var accountRepo, out var masterRepo, out var appRepo);
+            accountRepo.Setup(r => r.FindByEmailAsync("e"))!.ReturnsAsync((ApplicationUser?)null);
+            accountRepo.Setup(r => r.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var vm = new RegisterViewModel { Email = "e", Password = "p", FirstName="f", LastName="l", Role="Master" };
             var result = await service.RegisterAsync(vm);

--- a/smelite_app/smelite_app/Program.cs
+++ b/smelite_app/smelite_app/Program.cs
@@ -30,6 +30,7 @@ namespace smelite_app
             builder.Services.AddScoped<Repositories.ICraftRepository, Repositories.CraftRepository>();
             builder.Services.AddScoped<Repositories.IApprenticeRepository, Repositories.ApprenticeRepository>();
             builder.Services.AddScoped<Repositories.IMasterRepository, Repositories.MasterRepository>();
+            builder.Services.AddScoped<Repositories.IAccountRepository, Repositories.AccountRepository>();
 
             builder.Services.AddScoped<Services.ICraftService, Services.CraftService>();
             builder.Services.AddScoped<Services.IApprenticeService, Services.ApprenticeService>();

--- a/smelite_app/smelite_app/Repositories/AccountRepository.cs
+++ b/smelite_app/smelite_app/Repositories/AccountRepository.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Identity;
+using smelite_app.Models;
+
+namespace smelite_app.Repositories
+{
+    public class AccountRepository : IAccountRepository
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly SignInManager<ApplicationUser> _signInManager;
+
+        public AccountRepository(UserManager<ApplicationUser> userManager,
+                                 SignInManager<ApplicationUser> signInManager)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+        }
+
+        public Task<ApplicationUser?> FindByEmailAsync(string email)
+        {
+            return _userManager.FindByEmailAsync(email);
+        }
+
+        public Task<IdentityResult> CreateAsync(ApplicationUser user, string password)
+        {
+            return _userManager.CreateAsync(user, password);
+        }
+
+        public Task AddToRoleAsync(ApplicationUser user, string role)
+        {
+            return _userManager.AddToRoleAsync(user, role);
+        }
+
+        public Task<string> GenerateEmailConfirmationTokenAsync(ApplicationUser user)
+        {
+            return _userManager.GenerateEmailConfirmationTokenAsync(user);
+        }
+
+        public Task ConfirmEmailAsync(ApplicationUser user, string token)
+        {
+            return _userManager.ConfirmEmailAsync(user, token);
+        }
+
+        public Task<SignInResult> PasswordSignInAsync(string email, string password, bool isPersistent, bool lockoutOnFailure)
+        {
+            return _signInManager.PasswordSignInAsync(email, password, isPersistent, lockoutOnFailure);
+        }
+
+        public Task SignOutAsync()
+        {
+            return _signInManager.SignOutAsync();
+        }
+
+        public Task SignInAsync(ApplicationUser user, bool isPersistent)
+        {
+            return _signInManager.SignInAsync(user, isPersistent);
+        }
+    }
+}

--- a/smelite_app/smelite_app/Repositories/IAccountRepository.cs
+++ b/smelite_app/smelite_app/Repositories/IAccountRepository.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Identity;
+using smelite_app.Models;
+
+namespace smelite_app.Repositories
+{
+    public interface IAccountRepository
+    {
+        Task<ApplicationUser?> FindByEmailAsync(string email);
+        Task<IdentityResult> CreateAsync(ApplicationUser user, string password);
+        Task AddToRoleAsync(ApplicationUser user, string role);
+        Task<string> GenerateEmailConfirmationTokenAsync(ApplicationUser user);
+        Task ConfirmEmailAsync(ApplicationUser user, string token);
+        Task<SignInResult> PasswordSignInAsync(string email, string password, bool isPersistent, bool lockoutOnFailure);
+        Task SignOutAsync();
+        Task SignInAsync(ApplicationUser user, bool isPersistent);
+    }
+}


### PR DESCRIPTION
## Summary
- automatically sign in users after successful registration
- refactor account logic by moving identity operations into `AccountRepository`
- adapt tests to use the new repository layer

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874e8b72ce083309edd11a3e9f933ea