### PR TITLE
Improve admin info and craft offering features

### DIFF
--- a/smelite_app/smelite_app/Controllers/CraftsController.cs
+++ b/smelite_app/smelite_app/Controllers/CraftsController.cs
@@ -56,6 +56,7 @@ namespace smelite_app.Controllers
                     Id = o.Id,
                     Location = o.CraftLocation.Name,
                     Package = o.CraftPackage.Label ?? o.CraftPackage.SessionsCount.ToString(),
+                    SessionsCount = o.CraftPackage.SessionsCount,
                     Price = o.Price
                 }).ToList(),
                 MasterName = craft.MasterProfileCrafts

--- a/smelite_app/smelite_app/ViewModels/Craft/CraftOfferingDetailsViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Craft/CraftOfferingDetailsViewModel.cs
@@ -5,6 +5,7 @@ namespace smelite_app.ViewModels.Craft
         public int Id { get; set; }
         public string Location { get; set; } = string.Empty;
         public string Package { get; set; } = string.Empty;
+        public int SessionsCount { get; set; }
         public decimal Price { get; set; }
     }
 }

--- a/smelite_app/smelite_app/Views/Admin/Apprenticeships.cshtml
+++ b/smelite_app/smelite_app/Views/Admin/Apprenticeships.cshtml
@@ -3,7 +3,16 @@
 <h2>Apprenticeships</h2>
 <table class="table">
 <thead>
-<tr><th>Apprentice</th><th>Master</th><th>Craft</th><th>Status</th><th></th></tr>
+<tr>
+    <th>Apprentice</th>
+    <th>Master</th>
+    <th>Craft</th>
+    <th>Location</th>
+    <th>Sessions</th>
+    <th>Price</th>
+    <th>Status</th>
+    <th></th>
+</tr>
 </thead>
 <tbody>
 @foreach (var a in Model)
@@ -12,6 +21,9 @@
         <td>@a.ApprenticeProfile.ApplicationUser.Email</td>
         <td>@a.MasterProfile.ApplicationUser.Email</td>
         <td>@a.CraftOffering.Craft.Name</td>
+        <td>@a.CraftOffering.CraftLocation.Name</td>
+        <td>@a.CraftOffering.CraftPackage.SessionsCount</td>
+        <td>@a.CraftOffering.Price</td>
         <td>@a.Status</td>
         <td>
             <form asp-action="SetApprenticeshipStatus" method="post">

--- a/smelite_app/smelite_app/Views/Admin/Orders.cshtml
+++ b/smelite_app/smelite_app/Views/Admin/Orders.cshtml
@@ -4,7 +4,18 @@
 <h2>Orders</h2>
 <table class="table">
 <thead>
-<tr><th>Apprentice</th><th>Master</th><th>Total</th><th>Status</th><th></th></tr>
+<tr>
+    <th>Apprentice</th>
+    <th>Master</th>
+    <th>Total</th>
+    <th>Fee</th>
+    <th>To Master</th>
+    <th>Paid On</th>
+    <th>Method</th>
+    <th>Transaction</th>
+    <th>Status</th>
+    <th></th>
+</tr>
 </thead>
 <tbody>
 @foreach (var p in Model)
@@ -13,6 +24,11 @@
         <td>@p.Apprenticeship.ApprenticeProfile.ApplicationUser.Email</td>
         <td>@p.Apprenticeship.MasterProfile.ApplicationUser.Email</td>
         <td>@p.AmountTotal</td>
+        <td>@p.PlatformFee</td>
+        <td>@p.AmountToRecipient</td>
+        <td>@p.PaidOn.ToShortDateString()</td>
+        <td>@p.Method</td>
+        <td>@p.TransactionId</td>
         <td>@p.Status</td>
         <td>
             <form asp-action="SetPaymentStatus" method="post">

--- a/smelite_app/smelite_app/Views/Crafts/Details.cshtml
+++ b/smelite_app/smelite_app/Views/Crafts/Details.cshtml
@@ -15,6 +15,7 @@
         <tr>
             <th>Location</th>
             <th>Package</th>
+            <th>Sessions</th>
             <th>Price</th>
             <th></th>
         </tr>
@@ -25,6 +26,7 @@
         <tr>
             <td>@o.Location</td>
             <td>@o.Package</td>
+            <td>@o.SessionsCount</td>
             <td>@o.Price</td>
             <td>
                 @if (User.IsInRole("Apprentice"))

--- a/smelite_app/smelite_app/Views/Master/EditCraft.cshtml
+++ b/smelite_app/smelite_app/Views/Master/EditCraft.cshtml
@@ -55,6 +55,10 @@
                 <input asp-for="Offerings[i].SessionsCount" type="number" min="0" max="20" placeholder="Sessions" class="form-control mb-1" required />
                 <input asp-for="Offerings[i].PackageLabel" placeholder="Label" class="form-control mb-1" maxlength="100" />
                 <input asp-for="Offerings[i].Price" placeholder="Price" class="form-control" type="number" min="0" max="100000" step="0.01" required />
+                @if (Model.Offerings[i].Id == null)
+                {
+                    <button type="button" class="btn btn-sm btn-danger remove-offer mt-1">Remove</button>
+                }
             </div>
         }
     </div>
@@ -87,8 +91,13 @@
                 `<input name='Offerings[${index}].SessionsCount' type='number' min='0' max='20' class='form-control mb-1' placeholder='Sessions' required />` +
                 `<input name='Offerings[${index}].PackageLabel' class='form-control mb-1' placeholder='Label' maxlength='100' />` +
                 `<input name='Offerings[${index}].Price' class='form-control' placeholder='Price' type='number' min='0' max='100000' step='0.01' required />` +
+                `<button type='button' class='btn btn-sm btn-danger remove-offer mt-1'>Remove</button>` +
                 `</div>`;
             $("#offerings").append(template);
+        });
+
+        $(document).on("click", ".remove-offer", function () {
+            $(this).closest('.offering').remove();
         });
     </script>
 }


### PR DESCRIPTION
## Summary
- show sessions count for craft offerings
- include more details in admin apprenticeships and orders views
- allow removing unsaved craft offerings

## Testing
- `dotnet test --no-build` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_687522b88b888330b45e481d41d1ad96