### PR TITLE
Add email notifications

### DIFF
--- a/smelite_app/smelite_app.Tests/UnitTests/ApprenticeServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/ApprenticeServiceTests.cs
@@ -15,7 +15,7 @@ namespace smelite_app.Tests.UnitTests
             var appRepo = new Mock<IApprenticeRepository>();
             var craftRepo = new Mock<ICraftRepository>();
             craftRepo.Setup(r => r.GetCraftOfferingByIdAsync(1)).ReturnsAsync(new CraftOffering { Id = 1, Price = 50, Craft = new Craft { MasterProfileCrafts = new List<MasterProfileCraft>{ new MasterProfileCraft{ MasterProfileId=5 } } } });
-            var service = new ApprenticeService(appRepo.Object, craftRepo.Object);
+            var service = new ApprenticeService(appRepo.Object, craftRepo.Object, new EmailSender());
 
             await service.AddApprenticeshipAsync(2, 1);
 
@@ -30,7 +30,7 @@ namespace smelite_app.Tests.UnitTests
             var appRepo = new Mock<IApprenticeRepository>();
             var craftRepo = new Mock<ICraftRepository>();
             craftRepo.Setup(r => r.GetCraftOfferingByIdAsync(1)).ReturnsAsync((CraftOffering?)null);
-            var service = new ApprenticeService(appRepo.Object, craftRepo.Object);
+            var service = new ApprenticeService(appRepo.Object, craftRepo.Object, new EmailSender());
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => service.AddApprenticeshipAsync(1,1));
         }

--- a/smelite_app/smelite_app.Tests/UnitTests/MasterServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/MasterServiceTests.cs
@@ -20,7 +20,7 @@ namespace smelite_app.Tests.UnitTests
                 PersonalInformation = "pi"
             };
             repo.Setup(r => r.GetByUserIdAsync("1")).ReturnsAsync(profile);
-            var service = new MasterService(repo.Object);
+            var service = new MasterService(repo.Object, new EmailSender());
 
             var result = await service.GetProfileAsync("1");
 
@@ -33,7 +33,7 @@ namespace smelite_app.Tests.UnitTests
         {
             var repo = new Mock<IMasterRepository>();
             var env = new Mock<IWebHostEnvironment>();
-            var service = new MasterService(repo.Object);
+            var service = new MasterService(repo.Object, new EmailSender());
             var vm = new CraftViewModel { Name = "n", CraftDescription="d", ExperienceYears=1, CraftTypeId=1, Offerings=new List<CraftOfferingFormViewModel>() };
 
             await service.AddCraftAsync(2, vm, "root", "user");

--- a/smelite_app/smelite_app/Helpers/Variables.cs
+++ b/smelite_app/smelite_app/Helpers/Variables.cs
@@ -4,6 +4,7 @@ namespace smelite_app.Helpers
     {
         public static string defaultProfileImageUrl = "/Defaults/DefaultProfileImg.png";
         public static string defaultCraftImageUrl = "/Defaults/DefaultCraftImg.png";
+        public static string defaultEmail = "smelitebg@gmail.com";
 
     }
 }

--- a/smelite_app/smelite_app/Services/AccountService.cs
+++ b/smelite_app/smelite_app/Services/AccountService.cs
@@ -134,6 +134,9 @@ namespace smelite_app.Services
                 var link = urlHelper.Action("ConfirmEmail", "Account", new { userId = user.Id, code = token }, httpContext.Request.Scheme);
 
                 await _emailSender.SendEmailAsync(user.Email!, "Confirm your email", $"Please confirm your account by <a href='{link}'>clicking here</a>.");
+                await _emailSender.SendEmailAsync(Variables.defaultEmail,
+                    "New account created",
+                    $"User {user.Email} registered as {user.Role}.");
 
                 _logger.LogInformation("Successful registration for {Email}", model.Email);
             }
@@ -159,7 +162,12 @@ namespace smelite_app.Services
             var result = await _accountRepo.ConfirmEmailAsync(user, code);
 
             if (result.Succeeded)
+            {
                 _logger.LogInformation("Email confirmed for {Email}", user.Email);
+                await _emailSender.SendEmailAsync(Variables.defaultEmail,
+                    "Account verified",
+                    $"User {user.Email} has verified their account.");
+            }
             else
                 foreach (var error in result.Errors)
                     _logger.LogWarning("Email confirmation error: {Error}", error.Description);

--- a/smelite_app/smelite_app/Services/AdminService.cs
+++ b/smelite_app/smelite_app/Services/AdminService.cs
@@ -2,15 +2,18 @@ using Microsoft.EntityFrameworkCore;
 using smelite_app.Data;
 using smelite_app.Models;
 using smelite_app.Enums;
+using smelite_app.Helpers;
 
 namespace smelite_app.Services
 {
     public class AdminService : IAdminService
     {
         private readonly ApplicationDbContext _context;
-        public AdminService(ApplicationDbContext context)
+        private readonly EmailSender _emailSender;
+        public AdminService(ApplicationDbContext context, EmailSender emailSender)
         {
             _context = context;
+            _emailSender = emailSender ?? throw new ArgumentNullException(nameof(emailSender));
         }
 
         public Task<List<ApplicationUser>> GetUsersAsync()
@@ -76,6 +79,9 @@ namespace smelite_app.Services
                 payment.Apprenticeship.Status = ApprenticeshipStatus.Active.ToString();
             }
             await _context.SaveChangesAsync();
+            await _emailSender.SendEmailAsync(Variables.defaultEmail,
+                "Payment updated",
+                $"Payment {payment.Id} status changed to {status}.");
         }
 
         public Task<List<Payment>> GetPaymentsAsync()

--- a/smelite_app/smelite_app/Services/ApprenticeService.cs
+++ b/smelite_app/smelite_app/Services/ApprenticeService.cs
@@ -3,6 +3,7 @@ using smelite_app.Enums;
 using smelite_app.Models;
 using smelite_app.Repositories;
 using smelite_app.ViewModels.Apprentice;
+using smelite_app.Helpers;
 
 namespace smelite_app.Services
 {
@@ -10,11 +11,13 @@ namespace smelite_app.Services
     {
         private readonly IApprenticeRepository _apprenticeRepository;
         private readonly ICraftRepository _craftRepository;
+        private readonly EmailSender _emailSender;
 
-        public ApprenticeService(IApprenticeRepository apprenticeRepository, ICraftRepository craftRepository)
+        public ApprenticeService(IApprenticeRepository apprenticeRepository, ICraftRepository craftRepository, EmailSender emailSender)
         {
             _apprenticeRepository = apprenticeRepository ?? throw new ArgumentNullException(nameof(apprenticeRepository));
             _craftRepository = craftRepository ?? throw new ArgumentNullException(nameof(craftRepository));
+            _emailSender = emailSender ?? throw new ArgumentNullException(nameof(emailSender));
         }
 
         public Task<ApprenticeProfile?> GetByUserIdAsync(string userId)
@@ -72,6 +75,9 @@ namespace smelite_app.Services
             };
 
             await _apprenticeRepository.AddApprenticeshipAsync(apprenticeship);
+            await _emailSender.SendEmailAsync(Variables.defaultEmail,
+                "Apprenticeship requested",
+                $"Apprentice {apprenticeProfileId} requested offering {craftOfferingId}.");
         }
 
         public Task<List<Apprenticeship>> GetApprenticeshipsAsync(int apprenticeProfileId)

--- a/smelite_app/smelite_app/Services/MasterService.cs
+++ b/smelite_app/smelite_app/Services/MasterService.cs
@@ -11,11 +11,13 @@ namespace smelite_app.Services
     public class MasterService : IMasterService
     {
         private readonly IMasterRepository _masterRepository;
+        private readonly EmailSender _emailSender;
 
-        public MasterService(IMasterRepository masterRepository)
+        public MasterService(IMasterRepository masterRepository, EmailSender emailSender)
         {
             _masterRepository = masterRepository
                 ?? throw new ArgumentNullException(nameof(masterRepository));
+            _emailSender = emailSender ?? throw new ArgumentNullException(nameof(emailSender));
         }
 
         public Task<MasterProfile?> GetByUserIdAsync(string userId)
@@ -81,6 +83,9 @@ namespace smelite_app.Services
             }
 
             await _masterRepository.AddCraftAsync(masterProfileId, craft, offerings, images);
+            await _emailSender.SendEmailAsync(Variables.defaultEmail,
+                "Craft created",
+                $"Master {masterProfileId} created craft '{craft.Name}'.");
         }
 
         public Task<List<Craft>> GetCraftsAsync(int masterProfileId)


### PR DESCRIPTION
## Summary
- configure default notification email
- send notification emails for new accounts, account verification, craft creation, apprenticeship request and payment updates
- update service constructors and unit tests for new EmailSender dependency

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876603ca14c8330aa75d5b90255ea4f