### PR TITLE
Add password verification before profile edits

### DIFF
--- a/smelite_app/smelite_app/Controllers/AdminController.cs
+++ b/smelite_app/smelite_app/Controllers/AdminController.cs
@@ -59,6 +59,14 @@ namespace smelite_app.Controllers
             if (!ModelState.IsValid) return View(model);
             var user = await _userManager.GetUserAsync(User);
             if (user == null) return NotFound();
+
+            var passwordValid = await _userManager.CheckPasswordAsync(user, model.CurrentPassword!);
+            if (!passwordValid)
+            {
+                ModelState.AddModelError("CurrentPassword", "Invalid password.");
+                return View(model);
+            }
+
             bool changed = false;
             if (user.FirstName != model.FirstName) { user.FirstName = model.FirstName; changed = true; }
             if (user.LastName != model.LastName) { user.LastName = model.LastName; changed = true; }
@@ -89,11 +97,6 @@ namespace smelite_app.Controllers
                 await _userManager.UpdateAsync(user);
             if (!string.IsNullOrEmpty(model.NewPassword))
             {
-                if (string.IsNullOrEmpty(model.CurrentPassword))
-                {
-                    ModelState.AddModelError("CurrentPassword", "Current password is required.");
-                    return View(model);
-                }
                 var result = await _userManager.ChangePasswordAsync(user, model.CurrentPassword!, model.NewPassword!);
                 if (!result.Succeeded)
                 {

--- a/smelite_app/smelite_app/Controllers/ApprenticeController.cs
+++ b/smelite_app/smelite_app/Controllers/ApprenticeController.cs
@@ -43,6 +43,13 @@ namespace smelite_app.Controllers
             var profile = await _apprenticeService.GetByUserIdAsync(user.Id);
             if (profile == null) return NotFound();
 
+            var passwordValid = await _userManager.CheckPasswordAsync(user, model.CurrentPassword!);
+            if (!passwordValid)
+            {
+                ModelState.AddModelError("CurrentPassword", "Invalid password.");
+                return View(model);
+            }
+
             var vm = new EditApprenticeProfileViewModel
             {
                 FirstName = user.FirstName,
@@ -106,12 +113,6 @@ namespace smelite_app.Controllers
 
             if (!string.IsNullOrEmpty(model.NewPassword))
             {
-                if (string.IsNullOrEmpty(model.CurrentPassword))
-                {
-                    ModelState.AddModelError("CurrentPassword", "Current password is required.");
-                    return View(model);
-                }
-
                 var result = await _userManager.ChangePasswordAsync(user, model.CurrentPassword!, model.NewPassword!);
                 if (!result.Succeeded)
                 {

--- a/smelite_app/smelite_app/Controllers/MasterController.cs
+++ b/smelite_app/smelite_app/Controllers/MasterController.cs
@@ -47,6 +47,13 @@ namespace smelite_app.Controllers
             var profile = await _masterService.GetByUserIdAsync(user.Id);
             if (profile == null) return NotFound();
 
+            var passwordValid = await _userManager.CheckPasswordAsync(user, model.CurrentPassword!);
+            if (!passwordValid)
+            {
+                ModelState.AddModelError("CurrentPassword", "Invalid password.");
+                return View(model);
+            }
+
             var vm = new EditMasterProfileViewModel
             {
                 FirstName = user.FirstName,
@@ -110,12 +117,6 @@ namespace smelite_app.Controllers
 
             if (!string.IsNullOrEmpty(model.NewPassword))
             {
-                if (string.IsNullOrEmpty(model.CurrentPassword))
-                {
-                    ModelState.AddModelError("CurrentPassword", "Current password is required.");
-                    return View(model);
-                }
-
                 var result = await _userManager.ChangePasswordAsync(user, model.CurrentPassword!, model.NewPassword!);
                 if (!result.Succeeded)
                 {

--- a/smelite_app/smelite_app/ViewModels/Admin/EditAdminProfileViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Admin/EditAdminProfileViewModel.cs
@@ -22,6 +22,7 @@ namespace smelite_app.ViewModels.Admin
 
         public IFormFile? ProfileImage { get; set; }
 
+        [Required(ErrorMessage = "Current password is required.")]
         [DataType(DataType.Password)]
         public string? CurrentPassword { get; set; }
 

--- a/smelite_app/smelite_app/ViewModels/Apprentice/EditApprenticeProfileViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Apprentice/EditApprenticeProfileViewModel.cs
@@ -25,6 +25,7 @@ namespace smelite_app.ViewModels.Apprentice
         [MaxLength(2000)]
         public string? PersonalInformation { get; set; }
 
+        [Required(ErrorMessage = "Current password is required.")]
         [DataType(DataType.Password)]
         public string? CurrentPassword { get; set; }
 

--- a/smelite_app/smelite_app/ViewModels/Master/EditMasterProfileViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/Master/EditMasterProfileViewModel.cs
@@ -25,6 +25,7 @@ namespace smelite_app.ViewModels.Master
         [MaxLength(2000)]
         public string? PersonalInformation { get; set; }
 
+        [Required(ErrorMessage = "Current password is required.")]
         [DataType(DataType.Password)]
         public string? CurrentPassword { get; set; }
 

--- a/smelite_app/smelite_app/Views/Admin/EditProfile.cshtml
+++ b/smelite_app/smelite_app/Views/Admin/EditProfile.cshtml
@@ -26,7 +26,7 @@
         </div>
         <div class="edit-form-group">
             <label asp-for="CurrentPassword" class="profile-label"></label>
-            <input asp-for="CurrentPassword" class="filter-input" />
+            <input asp-for="CurrentPassword" class="filter-input" required />
         </div>
         <div class="edit-form-group">
             <label asp-for="NewPassword" class="profile-label"></label>

--- a/smelite_app/smelite_app/Views/Apprentice/EditProfile.cshtml
+++ b/smelite_app/smelite_app/Views/Apprentice/EditProfile.cshtml
@@ -30,7 +30,7 @@
         </div>
         <div class="edit-form-group">
             <label asp-for="CurrentPassword" class="profile-label"></label>
-            <input asp-for="CurrentPassword" class="filter-input" />
+            <input asp-for="CurrentPassword" class="filter-input" required />
         </div>
         <div class="edit-form-group">
             <label asp-for="NewPassword" class="profile-label"></label>

--- a/smelite_app/smelite_app/Views/Master/EditProfile.cshtml
+++ b/smelite_app/smelite_app/Views/Master/EditProfile.cshtml
@@ -30,7 +30,7 @@
         </div>
         <div class="edit-form-group">
             <label asp-for="CurrentPassword" class="profile-label"></label>
-            <input asp-for="CurrentPassword" class="filter-input" />
+            <input asp-for="CurrentPassword" class="filter-input" required />
         </div>
         <div class="edit-form-group">
             <label asp-for="NewPassword" class="profile-label"></label>


### PR DESCRIPTION
## Summary
- ensure password is required in profile edit view models
- update profile edit pages to enforce password input
- verify password in Admin, Apprentice and Master profile updates

## Testing
- `dotnet test smelite_app/smelite_app.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68772b0c42488330867cde9d846f24c3