### PR TITLE
Add email subscription system

### DIFF
--- a/smelite_app/smelite_app/Controllers/AdminController.cs
+++ b/smelite_app/smelite_app/Controllers/AdminController.cs
@@ -15,12 +15,14 @@ namespace smelite_app.Controllers
         private readonly IAdminService _adminService;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IWebHostEnvironment _environment;
+        private readonly IEmailSubscriptionService _subscriptionService;
 
-        public AdminController(IAdminService adminService, UserManager<ApplicationUser> userManager, IWebHostEnvironment environment)
+        public AdminController(IAdminService adminService, UserManager<ApplicationUser> userManager, IWebHostEnvironment environment, IEmailSubscriptionService subscriptionService)
         {
             _adminService = adminService;
             _userManager = userManager;
             _environment = environment;
+            _subscriptionService = subscriptionService;
         }
 
         public async Task<IActionResult> Profile()
@@ -154,6 +156,25 @@ namespace smelite_app.Controllers
         {
             var payments = await _adminService.GetPaymentsAsync();
             return View(payments);
+        }
+
+        public async Task<IActionResult> Subscribers()
+        {
+            var subs = await _subscriptionService.GetAllAsync();
+            return View(subs);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> ToggleSubscriber(int id)
+        {
+            var subs = await _subscriptionService.GetAllAsync();
+            var sub = subs.FirstOrDefault(s => s.Id == id);
+            if (sub != null)
+            {
+                await _subscriptionService.ToggleActiveAsync(id, !sub.IsActive);
+            }
+            return RedirectToAction(nameof(Subscribers));
         }
     }
 }

--- a/smelite_app/smelite_app/Controllers/HomeController.cs
+++ b/smelite_app/smelite_app/Controllers/HomeController.cs
@@ -1,16 +1,19 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using smelite_app.Models;
+using smelite_app.Services;
 
 namespace smelite_app.Controllers
 {
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
+        private readonly IEmailSubscriptionService _subscriptionService;
 
-        public HomeController(ILogger<HomeController> logger)
+        public HomeController(ILogger<HomeController> logger, IEmailSubscriptionService subscriptionService)
         {
             _logger = logger;
+            _subscriptionService = subscriptionService;
         }
 
         public IActionResult Index()
@@ -45,6 +48,20 @@ namespace smelite_app.Controllers
         public IActionResult TermsAndConditions()
         {
             return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Subscribe(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                TempData["Notification"] = "Невалиден имейл";
+                return RedirectToAction(nameof(Index));
+            }
+            await _subscriptionService.SubscribeAsync(email);
+            TempData["Notification"] = "Благодарим за абонамента";
+            return RedirectToAction(nameof(Index));
         }
 
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/smelite_app/smelite_app/Data/ApplicationDbContext.cs
+++ b/smelite_app/smelite_app/Data/ApplicationDbContext.cs
@@ -28,6 +28,8 @@ namespace smelite_app.Data
 
         public DbSet<BlogPost> BlogPosts { get; set; }
 
+        public DbSet<EmailSubscription> EmailSubscriptions { get; set; }
+
 
         protected override void OnModelCreating(ModelBuilder builder)
         {

--- a/smelite_app/smelite_app/Migrations/20250728110000_AddEmailSubscription.cs
+++ b/smelite_app/smelite_app/Migrations/20250728110000_AddEmailSubscription.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace smelite_app.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailSubscription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EmailSubscriptions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Email = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false),
+                    SubscribedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmailSubscriptions", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EmailSubscriptions");
+        }
+    }
+}

--- a/smelite_app/smelite_app/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/smelite_app/smelite_app/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -337,6 +337,29 @@ namespace smelite_app.Migrations
                     b.ToTable("BlogPosts");
                 });
 
+            modelBuilder.Entity("smelite_app.Models.EmailSubscription", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("Email")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("bit");
+
+                    b.Property<DateTime>("SubscribedAt")
+                        .HasColumnType("datetime2");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("EmailSubscriptions");
+                });
+
             modelBuilder.Entity("smelite_app.Models.Craft", b =>
                 {
                     b.Property<int>("Id")

--- a/smelite_app/smelite_app/Models/EmailSubscription.cs
+++ b/smelite_app/smelite_app/Models/EmailSubscription.cs
@@ -1,0 +1,18 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace smelite_app.Models
+{
+    public class EmailSubscription
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; }
+
+        public bool IsActive { get; set; } = true;
+
+        public DateTime SubscribedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/smelite_app/smelite_app/Program.cs
+++ b/smelite_app/smelite_app/Program.cs
@@ -65,6 +65,8 @@ namespace smelite_app
 
             builder.Services.AddScoped<Repositories.IBlogRepository, Repositories.BlogRepository>();
 
+            builder.Services.AddScoped<Repositories.IEmailSubscriptionRepository, Repositories.EmailSubscriptionRepository>();
+
             builder.Services.AddScoped<Services.ICraftService, Services.CraftService>();
             builder.Services.AddScoped<Services.IApprenticeService, Services.ApprenticeService>();
             builder.Services.AddScoped<Services.IMasterService, Services.MasterService>();
@@ -74,6 +76,7 @@ namespace smelite_app
             builder.Services.AddScoped<LogActionFilter>();
             builder.Services.AddScoped<Services.IPaymentService, Services.PaymentService>();
             builder.Services.AddScoped<Services.IBlogService, Services.BlogService>();
+            builder.Services.AddScoped<Services.IEmailSubscriptionService, Services.EmailSubscriptionService>();
 
             StripeConfiguration.ApiKey = builder.Configuration["Stripe:SecretKey"];
 

--- a/smelite_app/smelite_app/Repositories/EmailSubscriptionRepository.cs
+++ b/smelite_app/smelite_app/Repositories/EmailSubscriptionRepository.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using smelite_app.Data;
+using smelite_app.Models;
+
+namespace smelite_app.Repositories
+{
+    public class EmailSubscriptionRepository : IEmailSubscriptionRepository
+    {
+        private readonly ApplicationDbContext _context;
+        public EmailSubscriptionRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public IQueryable<EmailSubscription> GetAll()
+        {
+            return _context.EmailSubscriptions;
+        }
+
+        public Task<EmailSubscription?> GetByIdAsync(int id)
+        {
+            return _context.EmailSubscriptions.FirstOrDefaultAsync(s => s.Id == id);
+        }
+
+        public Task<EmailSubscription?> GetByEmailAsync(string email)
+        {
+            return _context.EmailSubscriptions.FirstOrDefaultAsync(s => s.Email == email);
+        }
+
+        public async Task AddAsync(EmailSubscription subscription)
+        {
+            _context.EmailSubscriptions.Add(subscription);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateAsync(EmailSubscription subscription)
+        {
+            _context.EmailSubscriptions.Update(subscription);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/smelite_app/smelite_app/Repositories/IEmailSubscriptionRepository.cs
+++ b/smelite_app/smelite_app/Repositories/IEmailSubscriptionRepository.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using smelite_app.Models;
+using System.Threading.Tasks;
+
+namespace smelite_app.Repositories
+{
+    public interface IEmailSubscriptionRepository
+    {
+        IQueryable<EmailSubscription> GetAll();
+        Task<EmailSubscription?> GetByIdAsync(int id);
+        Task<EmailSubscription?> GetByEmailAsync(string email);
+        Task AddAsync(EmailSubscription subscription);
+        Task UpdateAsync(EmailSubscription subscription);
+    }
+}

--- a/smelite_app/smelite_app/Services/BlogService.cs
+++ b/smelite_app/smelite_app/Services/BlogService.cs
@@ -1,15 +1,21 @@
 using Microsoft.EntityFrameworkCore;
 using smelite_app.Models;
 using smelite_app.Repositories;
+using smelite_app.Helpers;
 
 namespace smelite_app.Services
 {
     public class BlogService : IBlogService
     {
         private readonly IBlogRepository _repo;
-        public BlogService(IBlogRepository repo)
+        private readonly EmailSender _emailSender;
+        private readonly IEmailSubscriptionService _subscriptionService;
+
+        public BlogService(IBlogRepository repo, EmailSender emailSender, IEmailSubscriptionService subscriptionService)
         {
             _repo = repo;
+            _emailSender = emailSender;
+            _subscriptionService = subscriptionService;
         }
 
         public Task<List<BlogPost>> GetAllAsync()
@@ -32,9 +38,15 @@ namespace smelite_app.Services
             return _repo.GetAll().Where(p => p.IsPublished).FirstOrDefaultAsync(p => p.Id == id);
         }
 
-        public Task AddAsync(BlogPost post)
+        public async Task AddAsync(BlogPost post)
         {
-            return _repo.AddAsync(post);
+            await _repo.AddAsync(post);
+            var emails = await _subscriptionService.GetActiveEmailsAsync();
+            foreach (var email in emails)
+            {
+                var link = $"/Blog/Details/{post.Id}";
+                await _emailSender.SendEmailAsync(email, post.Title, $"{post.Content}<br/><a href='{link}'>Прочети повече</a>");
+            }
         }
 
         public Task UpdateAsync(BlogPost post)

--- a/smelite_app/smelite_app/Services/EmailSubscriptionService.cs
+++ b/smelite_app/smelite_app/Services/EmailSubscriptionService.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using smelite_app.Models;
+using smelite_app.Repositories;
+
+namespace smelite_app.Services
+{
+    public class EmailSubscriptionService : IEmailSubscriptionService
+    {
+        private readonly IEmailSubscriptionRepository _repo;
+        public EmailSubscriptionService(IEmailSubscriptionRepository repo)
+        {
+            _repo = repo;
+        }
+
+        public Task<List<EmailSubscription>> GetAllAsync()
+        {
+            return _repo.GetAll().ToListAsync();
+        }
+
+        public async Task SubscribeAsync(string email)
+        {
+            var existing = await _repo.GetByEmailAsync(email);
+            if (existing != null)
+            {
+                if (!existing.IsActive)
+                {
+                    existing.IsActive = true;
+                    await _repo.UpdateAsync(existing);
+                }
+                return;
+            }
+
+            var subscription = new EmailSubscription { Email = email };
+            await _repo.AddAsync(subscription);
+        }
+
+        public async Task ToggleActiveAsync(int id, bool isActive)
+        {
+            var sub = await _repo.GetByIdAsync(id);
+            if (sub != null)
+            {
+                sub.IsActive = isActive;
+                await _repo.UpdateAsync(sub);
+            }
+        }
+
+        public Task<List<string>> GetActiveEmailsAsync()
+        {
+            return _repo.GetAll().Where(s => s.IsActive).Select(s => s.Email).ToListAsync();
+        }
+    }
+}

--- a/smelite_app/smelite_app/Services/IEmailSubscriptionService.cs
+++ b/smelite_app/smelite_app/Services/IEmailSubscriptionService.cs
@@ -1,0 +1,12 @@
+using smelite_app.Models;
+
+namespace smelite_app.Services
+{
+    public interface IEmailSubscriptionService
+    {
+        Task<List<EmailSubscription>> GetAllAsync();
+        Task SubscribeAsync(string email);
+        Task ToggleActiveAsync(int id, bool isActive);
+        Task<List<string>> GetActiveEmailsAsync();
+    }
+}

--- a/smelite_app/smelite_app/Views/Admin/Profile.cshtml
+++ b/smelite_app/smelite_app/Views/Admin/Profile.cshtml
@@ -20,5 +20,6 @@
         <a asp-action="Users" class="btn-main-outline profile-btn">Потребители</a>
         <a asp-action="Apprenticeships" class="btn-main-outline profile-btn">Чиракувания</a>
         <a asp-action="Orders" class="btn-main-outline profile-btn">Поръчки</a>
+        <a asp-action="Subscribers" class="btn-main-outline profile-btn">Имейл абонати</a>
     </div>
 </div>

--- a/smelite_app/smelite_app/Views/Admin/Subscribers.cshtml
+++ b/smelite_app/smelite_app/Views/Admin/Subscribers.cshtml
@@ -1,0 +1,23 @@
+@model IEnumerable<smelite_app.Models.EmailSubscription>
+
+<h2 class="craft-title" style="text-align:center;margin-bottom:34px;">Email Subscribers</h2>
+<table class="crafts-table crafts-table-wrap">
+<thead>
+<tr><th>Email</th><th>Active</th><th></th></tr>
+</thead>
+<tbody>
+@foreach (var s in Model)
+{
+    <tr>
+        <td>@s.Email</td>
+        <td>@s.IsActive</td>
+        <td>
+            <form asp-action="ToggleSubscriber" method="post">
+                <input type="hidden" name="id" value="@s.Id" />
+                <button type="submit" class="btn-main-outline btn-xs">@(s.IsActive ? "Deactivate" : "Activate")</button>
+            </form>
+        </td>
+    </tr>
+}
+</tbody>
+</table>

--- a/smelite_app/smelite_app/Views/Home/Index.cshtml
+++ b/smelite_app/smelite_app/Views/Home/Index.cshtml
@@ -91,3 +91,11 @@
         <a href="/Home/Merch" class="cta-btn">ПОДКРЕПИ НИ</a>
     </div>
 </section>
+
+<!-- Subscribe section -->
+<section class="subscribe-section" style="margin-top:40px;text-align:center;">
+    <form asp-action="Subscribe" method="post" class="subscribe-form">
+        <input type="email" name="email" placeholder="Въведи имейл" class="filter-input" required />
+        <button type="submit" class="btn-main">Абонирай се</button>
+    </form>
+</section>


### PR DESCRIPTION
## Summary
- add `EmailSubscription` model and migration
- create repository & service for subscriptions
- send email to all active subscribers when a blog post is created
- allow visitors to subscribe from the home page
- allow admin to manage subscriber activation state

## Testing
- `dotnet test smelite_app/smelite_app.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688755b5b35c8330b559f002791beb80