### PR TITLE
Add craft type admin management

### DIFF
--- a/smelite_app/smelite_app/Controllers/CraftTypeAdminController.cs
+++ b/smelite_app/smelite_app/Controllers/CraftTypeAdminController.cs
@@ -1,0 +1,79 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using smelite_app.Models;
+using smelite_app.Services;
+
+namespace smelite_app.Controllers
+{
+    [Authorize(Roles = "Admin")]
+    public class CraftTypeAdminController : Controller
+    {
+        private readonly ICraftService _craftService;
+        public CraftTypeAdminController(ICraftService craftService)
+        {
+            _craftService = craftService;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var types = await _craftService.GetCraftTypesAsync();
+            return View(types);
+        }
+
+        [HttpGet]
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create(CraftType model)
+        {
+            if (!ModelState.IsValid)
+                return View(model);
+
+            await _craftService.AddCraftTypeAsync(model);
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null) return NotFound();
+            var type = await _craftService.GetCraftTypeByIdAsync(id.Value);
+            if (type == null) return NotFound();
+            return View(type);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, CraftType model)
+        {
+            if (!ModelState.IsValid)
+                return View(model);
+            var type = await _craftService.GetCraftTypeByIdAsync(id);
+            if (type == null) return NotFound();
+            type.Name = model.Name;
+            await _craftService.UpdateCraftTypeAsync(type);
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null) return NotFound();
+            var type = await _craftService.GetCraftTypeByIdAsync(id.Value);
+            if (type == null) return NotFound();
+            return View(type);
+        }
+
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            await _craftService.SoftDeleteCraftTypeAsync(id);
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}

--- a/smelite_app/smelite_app/Repositories/CraftRepository.cs
+++ b/smelite_app/smelite_app/Repositories/CraftRepository.cs
@@ -58,6 +58,23 @@ namespace smelite_app.Repositories
             return _context.CraftTypes.ToListAsync();
         }
 
+        public Task<CraftType?> GetCraftTypeByIdAsync(int craftTypeId)
+        {
+            return _context.CraftTypes.FirstOrDefaultAsync(ct => ct.Id == craftTypeId);
+        }
+
+        public async Task AddCraftTypeAsync(CraftType craftType)
+        {
+            _context.CraftTypes.Add(craftType);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateCraftTypeAsync(CraftType craftType)
+        {
+            _context.CraftTypes.Update(craftType);
+            await _context.SaveChangesAsync();
+        }
+
         public Task<List<CraftLocation>> GetLocationsAsync()
         {
             return _context.CraftLocations.ToListAsync();

--- a/smelite_app/smelite_app/Repositories/ICraftRepository.cs
+++ b/smelite_app/smelite_app/Repositories/ICraftRepository.cs
@@ -11,6 +11,9 @@ namespace smelite_app.Repositories
         IQueryable<Craft> GetCrafts();
         Task<Craft?> GetCraftByIdAsync(int craftId);
         Task<List<CraftType>> GetCraftTypesAsync();
+        Task<CraftType?> GetCraftTypeByIdAsync(int craftTypeId);
+        Task AddCraftTypeAsync(CraftType craftType);
+        Task UpdateCraftTypeAsync(CraftType craftType);
 
         Task<List<CraftLocation>> GetLocationsAsync();
         Task<List<CraftPackage>> GetPackagesAsync();

--- a/smelite_app/smelite_app/Services/CraftService.cs
+++ b/smelite_app/smelite_app/Services/CraftService.cs
@@ -67,6 +67,21 @@ namespace smelite_app.Services
             return _repository.GetCraftTypesAsync();
         }
 
+        public Task<CraftType?> GetCraftTypeByIdAsync(int id)
+        {
+            return _repository.GetCraftTypeByIdAsync(id);
+        }
+
+        public Task AddCraftTypeAsync(CraftType craftType)
+        {
+            return _repository.AddCraftTypeAsync(craftType);
+        }
+
+        public Task UpdateCraftTypeAsync(CraftType craftType)
+        {
+            return _repository.UpdateCraftTypeAsync(craftType);
+        }
+
         public Task<List<CraftLocation>> GetLocationsAsync()
         {
             return _repository.GetLocationsAsync();

--- a/smelite_app/smelite_app/Services/ICraftService.cs
+++ b/smelite_app/smelite_app/Services/ICraftService.cs
@@ -10,6 +10,9 @@ namespace smelite_app.Services
         Task<IEnumerable<Craft>> GetFilteredCraftsAsync(int? craftTypeId, int? locationId, string? searchName);
         Task<Craft?> GetCraftByIdAsync(int id);
         Task<List<CraftType>> GetCraftTypesAsync();
+        Task<CraftType?> GetCraftTypeByIdAsync(int id);
+        Task AddCraftTypeAsync(CraftType craftType);
+        Task UpdateCraftTypeAsync(CraftType craftType);
         Task<List<CraftLocation>> GetLocationsAsync();
         Task<List<CraftPackage>> GetPackagesAsync();
 

--- a/smelite_app/smelite_app/Views/Admin/Profile.cshtml
+++ b/smelite_app/smelite_app/Views/Admin/Profile.cshtml
@@ -22,5 +22,6 @@
         <a asp-action="Orders" class="btn-main-outline profile-btn">Поръчки</a>
         <a asp-action="Subscribers" class="btn-main-outline profile-btn">Имейл абонати</a>
         <a asp-controller="BlogAdmin" asp-action="Index" class="btn-main-outline profile-btn">Блог постове</a>
+        <a asp-controller="CraftTypeAdmin" asp-action="Index" class="btn-main-outline profile-btn">Craft Types</a>
     </div>
 </div>

--- a/smelite_app/smelite_app/Views/CraftTypeAdmin/Create.cshtml
+++ b/smelite_app/smelite_app/Views/CraftTypeAdmin/Create.cshtml
@@ -1,0 +1,12 @@
+@model smelite_app.Models.CraftType
+
+<h2 class="craft-title" style="text-align:center;margin-bottom:34px;">Create Craft Type</h2>
+
+<form asp-action="Create" method="post" class="edit-profile-form">
+    <div class="edit-form-group">
+        <label asp-for="Name" class="profile-label"></label>
+        <input asp-for="Name" class="filter-input" />
+        <span asp-validation-for="Name" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn-main">Create</button>
+</form>

--- a/smelite_app/smelite_app/Views/CraftTypeAdmin/Delete.cshtml
+++ b/smelite_app/smelite_app/Views/CraftTypeAdmin/Delete.cshtml
@@ -1,0 +1,14 @@
+@model smelite_app.Models.CraftType
+
+<h2 class="craft-title" style="text-align:center;margin-bottom:34px;">Delete Craft Type</h2>
+
+<div class="profile-card master-profile-card">
+    <h3>@Model.Name</h3>
+    <p>Are you sure you want to delete this?</p>
+</div>
+
+<form asp-action="Delete" method="post">
+    <input type="hidden" asp-for="Id" />
+    <button type="submit" class="btn-main">Delete</button>
+    <a asp-action="Index" class="btn-main-outline">Cancel</a>
+</form>

--- a/smelite_app/smelite_app/Views/CraftTypeAdmin/Edit.cshtml
+++ b/smelite_app/smelite_app/Views/CraftTypeAdmin/Edit.cshtml
@@ -1,0 +1,13 @@
+@model smelite_app.Models.CraftType
+
+<h2 class="craft-title" style="text-align:center;margin-bottom:34px;">Edit Craft Type</h2>
+
+<form asp-action="Edit" asp-route-id="@Model.Id" method="post" class="edit-profile-form">
+    <input type="hidden" asp-for="Id" />
+    <div class="edit-form-group">
+        <label asp-for="Name" class="profile-label"></label>
+        <input asp-for="Name" class="filter-input" />
+        <span asp-validation-for="Name" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn-main">Save</button>
+</form>

--- a/smelite_app/smelite_app/Views/CraftTypeAdmin/Index.cshtml
+++ b/smelite_app/smelite_app/Views/CraftTypeAdmin/Index.cshtml
@@ -1,0 +1,26 @@
+@model IEnumerable<smelite_app.Models.CraftType>
+
+<h2 class="craft-title" style="text-align:center;margin-bottom:34px;">Craft Types</h2>
+<p>
+    <a asp-action="Create" class="btn-main">Create New</a>
+</p>
+<table class="crafts-table crafts-table-wrap">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var item in Model)
+    {
+        <tr>
+            <td>@item.Name</td>
+            <td>
+                <a asp-action="Edit" asp-route-id="@item.Id" class="btn-main-outline btn-xs">Edit</a> |
+                <a asp-action="Delete" asp-route-id="@item.Id" class="btn-main-outline btn-xs">Delete</a>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>


### PR DESCRIPTION
## Summary
- allow admin CRUD operations for craft types
- implement repository and service methods for craft types
- add CraftTypeAdminController and views
- link craft type management from admin profile

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876bf1c998833099368eb1ba77cb66