### PR TITLE
Use viewmodels for craft type CRUD operations

### DIFF
--- a/smelite_app/smelite_app/Controllers/CraftTypeAdminController.cs
+++ b/smelite_app/smelite_app/Controllers/CraftTypeAdminController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using smelite_app.Models;
+using smelite_app.ViewModels.CraftType;
 using smelite_app.Services;
 using System.Globalization;
+using System.Linq;
 
 namespace smelite_app.Controllers
 {
@@ -18,18 +20,23 @@ namespace smelite_app.Controllers
         public async Task<IActionResult> Index()
         {
             var types = await _craftService.GetCraftTypesAsync();
-            return View(types);
+            var vm = types.Select(t => new CraftTypeListItemViewModel
+            {
+                Id = t.Id,
+                Name = t.Name
+            }).ToList();
+            return View(vm);
         }
 
         [HttpGet]
         public IActionResult Create()
         {
-            return View();
+            return View(new CraftTypeViewModel());
         }
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create(CraftType model)
+        public async Task<IActionResult> Create(CraftTypeViewModel model)
         {
             if (!ModelState.IsValid)
                 return View(model);
@@ -39,7 +46,11 @@ namespace smelite_app.Controllers
                 model.Name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(model.Name.ToLower());
             }
 
-            await _craftService.AddCraftTypeAsync(model);
+            var craftType = new CraftType
+            {
+                Name = model.Name
+            };
+            await _craftService.AddCraftTypeAsync(craftType);
             return RedirectToAction(nameof(Index));
         }
 
@@ -49,12 +60,17 @@ namespace smelite_app.Controllers
             if (id == null) return NotFound();
             var type = await _craftService.GetCraftTypeByIdAsync(id.Value);
             if (type == null) return NotFound();
-            return View(type);
+            var vm = new CraftTypeViewModel
+            {
+                Id = type.Id,
+                Name = type.Name
+            };
+            return View(vm);
         }
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(int id, CraftType model)
+        public async Task<IActionResult> Edit(int id, CraftTypeViewModel model)
         {
             if (!ModelState.IsValid)
                 return View(model);
@@ -71,7 +87,12 @@ namespace smelite_app.Controllers
             if (id == null) return NotFound();
             var type = await _craftService.GetCraftTypeByIdAsync(id.Value);
             if (type == null) return NotFound();
-            return View(type);
+            var vm = new CraftTypeViewModel
+            {
+                Id = type.Id,
+                Name = type.Name
+            };
+            return View(vm);
         }
 
         [HttpPost, ActionName("Delete")]

--- a/smelite_app/smelite_app/ViewModels/CraftType/CraftTypeListItemViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/CraftType/CraftTypeListItemViewModel.cs
@@ -1,0 +1,8 @@
+namespace smelite_app.ViewModels.CraftType
+{
+    public class CraftTypeListItemViewModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/smelite_app/smelite_app/ViewModels/CraftType/CraftTypeViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/CraftType/CraftTypeViewModel.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace smelite_app.ViewModels.CraftType
+{
+    public class CraftTypeViewModel
+    {
+        public int? Id { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/smelite_app/smelite_app/Views/CraftTypeAdmin/Create.cshtml
+++ b/smelite_app/smelite_app/Views/CraftTypeAdmin/Create.cshtml
@@ -1,4 +1,4 @@
-@model smelite_app.Models.CraftType
+@model smelite_app.ViewModels.CraftType.CraftTypeViewModel
 
 <h2 class="craft-title" style="text-align:center;margin-bottom:34px;">Create Craft Type</h2>
 

--- a/smelite_app/smelite_app/Views/CraftTypeAdmin/Delete.cshtml
+++ b/smelite_app/smelite_app/Views/CraftTypeAdmin/Delete.cshtml
@@ -1,4 +1,4 @@
-@model smelite_app.Models.CraftType
+@model smelite_app.ViewModels.CraftType.CraftTypeViewModel
 
 <h2 class="craft-title" style="text-align:center;margin-bottom:34px;">Delete Craft Type</h2>
 

--- a/smelite_app/smelite_app/Views/CraftTypeAdmin/Edit.cshtml
+++ b/smelite_app/smelite_app/Views/CraftTypeAdmin/Edit.cshtml
@@ -1,4 +1,4 @@
-@model smelite_app.Models.CraftType
+@model smelite_app.ViewModels.CraftType.CraftTypeViewModel
 
 <h2 class="craft-title" style="text-align:center;margin-bottom:34px;">Edit Craft Type</h2>
 

--- a/smelite_app/smelite_app/Views/CraftTypeAdmin/Index.cshtml
+++ b/smelite_app/smelite_app/Views/CraftTypeAdmin/Index.cshtml
@@ -1,4 +1,4 @@
-@model IEnumerable<smelite_app.Models.CraftType>
+@model IEnumerable<smelite_app.ViewModels.CraftType.CraftTypeListItemViewModel>
 
 <h2 class="craft-title" style="text-align:center;margin-bottom:34px;">Craft Types</h2>
 <p>


### PR DESCRIPTION
## Summary
- add CraftType view models
- update CraftType admin controller to return view models
- update CraftType admin views to use view models

## Testing
- `dotnet test smelite_app/smelite_app.Tests/smelite_app.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887899b230483309587e8c55f46316f