### PR TITLE
Add craft type activation toggle

### DIFF
--- a/smelite_app/smelite_app.Tests/IntegrationTests/CraftTypeToggleTests.cs
+++ b/smelite_app/smelite_app.Tests/IntegrationTests/CraftTypeToggleTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using smelite_app.Repositories;
+using smelite_app.Services;
+using smelite_app.Models;
+using Xunit;
+
+namespace smelite_app.Tests.IntegrationTests
+{
+    public class CraftTypeToggleTests
+    {
+        [Fact]
+        public async Task ToggleCraftType_SetsIsDeletedFlag()
+        {
+            using var context = TestHelper.GetInMemoryDbContext();
+            var type = new CraftType { Id = 1, Name = "Type", IsDeleted = false };
+            context.CraftTypes.Add(type);
+            await context.SaveChangesAsync();
+
+            var repo = new CraftRepository(context);
+            var service = new CraftService(repo);
+
+            await service.ToggleCraftTypeAsync(1, false);
+            var stored = context.CraftTypes.IgnoreQueryFilters().Single(ct => ct.Id == 1);
+            Assert.True(stored.IsDeleted);
+
+            await service.ToggleCraftTypeAsync(1, true);
+            stored = context.CraftTypes.IgnoreQueryFilters().Single(ct => ct.Id == 1);
+            Assert.False(stored.IsDeleted);
+        }
+    }
+}

--- a/smelite_app/smelite_app.Tests/UnitTests/CraftServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/CraftServiceTests.cs
@@ -31,5 +31,16 @@ namespace smelite_app.Tests.UnitTests
 
             Assert.Equal(craft, result);
         }
+
+        [Fact]
+        public async Task ToggleCraftType_CallsRepository()
+        {
+            var repo = new Mock<ICraftRepository>();
+            var service = new CraftService(repo.Object);
+
+            await service.ToggleCraftTypeAsync(2, true);
+
+            repo.Verify(r => r.ToggleCraftTypeAsync(2, true), Times.Once);
+        }
     }
 }

--- a/smelite_app/smelite_app/Controllers/CraftTypeAdminController.cs
+++ b/smelite_app/smelite_app/Controllers/CraftTypeAdminController.cs
@@ -19,11 +19,12 @@ namespace smelite_app.Controllers
 
         public async Task<IActionResult> Index()
         {
-            var types = await _craftService.GetCraftTypesAsync();
+            var types = await _craftService.GetAllCraftTypesAsync();
             var vm = types.Select(t => new CraftTypeListItemViewModel
             {
                 Id = t.Id,
-                Name = t.Name
+                Name = t.Name,
+                IsActive = !t.IsDeleted
             }).ToList();
             return View(vm);
         }
@@ -58,7 +59,7 @@ namespace smelite_app.Controllers
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null) return NotFound();
-            var type = await _craftService.GetCraftTypeByIdAsync(id.Value);
+            var type = await _craftService.GetCraftTypeByIdAllAsync(id.Value);
             if (type == null) return NotFound();
             var vm = new CraftTypeViewModel
             {
@@ -74,7 +75,7 @@ namespace smelite_app.Controllers
         {
             if (!ModelState.IsValid)
                 return View(model);
-            var type = await _craftService.GetCraftTypeByIdAsync(id);
+            var type = await _craftService.GetCraftTypeByIdAllAsync(id);
             if (type == null) return NotFound();
             type.Name = model.Name;
             await _craftService.UpdateCraftTypeAsync(type);
@@ -85,7 +86,7 @@ namespace smelite_app.Controllers
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null) return NotFound();
-            var type = await _craftService.GetCraftTypeByIdAsync(id.Value);
+            var type = await _craftService.GetCraftTypeByIdAllAsync(id.Value);
             if (type == null) return NotFound();
             var vm = new CraftTypeViewModel
             {
@@ -100,6 +101,14 @@ namespace smelite_app.Controllers
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             await _craftService.SoftDeleteCraftTypeAsync(id);
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Toggle(int id, bool active)
+        {
+            await _craftService.ToggleCraftTypeAsync(id, active);
             return RedirectToAction(nameof(Index));
         }
     }

--- a/smelite_app/smelite_app/Repositories/CraftRepository.cs
+++ b/smelite_app/smelite_app/Repositories/CraftRepository.cs
@@ -58,9 +58,23 @@ namespace smelite_app.Repositories
             return _context.CraftTypes.ToListAsync();
         }
 
+        public Task<List<CraftType>> GetAllCraftTypesAsync()
+        {
+            return _context.CraftTypes
+                .IgnoreQueryFilters()
+                .ToListAsync();
+        }
+
         public Task<CraftType?> GetCraftTypeByIdAsync(int craftTypeId)
         {
             return _context.CraftTypes.FirstOrDefaultAsync(ct => ct.Id == craftTypeId);
+        }
+
+        public Task<CraftType?> GetCraftTypeByIdAllAsync(int craftTypeId)
+        {
+            return _context.CraftTypes
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(ct => ct.Id == craftTypeId);
         }
 
         public async Task AddCraftTypeAsync(CraftType craftType)
@@ -73,6 +87,18 @@ namespace smelite_app.Repositories
         {
             _context.CraftTypes.Update(craftType);
             await _context.SaveChangesAsync();
+        }
+
+        public async Task ToggleCraftTypeAsync(int craftTypeId, bool isActive)
+        {
+            var type = await _context.CraftTypes
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(ct => ct.Id == craftTypeId);
+            if (type != null)
+            {
+                type.IsDeleted = !isActive;
+                await _context.SaveChangesAsync();
+            }
         }
 
         public Task<List<CraftLocation>> GetLocationsAsync()

--- a/smelite_app/smelite_app/Repositories/ICraftRepository.cs
+++ b/smelite_app/smelite_app/Repositories/ICraftRepository.cs
@@ -11,9 +11,12 @@ namespace smelite_app.Repositories
         IQueryable<Craft> GetCrafts();
         Task<Craft?> GetCraftByIdAsync(int craftId);
         Task<List<CraftType>> GetCraftTypesAsync();
+        Task<List<CraftType>> GetAllCraftTypesAsync();
         Task<CraftType?> GetCraftTypeByIdAsync(int craftTypeId);
+        Task<CraftType?> GetCraftTypeByIdAllAsync(int craftTypeId);
         Task AddCraftTypeAsync(CraftType craftType);
         Task UpdateCraftTypeAsync(CraftType craftType);
+        Task ToggleCraftTypeAsync(int craftTypeId, bool isActive);
 
         Task<List<CraftLocation>> GetLocationsAsync();
         Task<List<CraftPackage>> GetPackagesAsync();

--- a/smelite_app/smelite_app/Services/CraftService.cs
+++ b/smelite_app/smelite_app/Services/CraftService.cs
@@ -67,9 +67,19 @@ namespace smelite_app.Services
             return _repository.GetCraftTypesAsync();
         }
 
+        public Task<List<CraftType>> GetAllCraftTypesAsync()
+        {
+            return _repository.GetAllCraftTypesAsync();
+        }
+
         public Task<CraftType?> GetCraftTypeByIdAsync(int id)
         {
             return _repository.GetCraftTypeByIdAsync(id);
+        }
+
+        public Task<CraftType?> GetCraftTypeByIdAllAsync(int id)
+        {
+            return _repository.GetCraftTypeByIdAllAsync(id);
         }
 
         public Task AddCraftTypeAsync(CraftType craftType)
@@ -80,6 +90,11 @@ namespace smelite_app.Services
         public Task UpdateCraftTypeAsync(CraftType craftType)
         {
             return _repository.UpdateCraftTypeAsync(craftType);
+        }
+
+        public Task ToggleCraftTypeAsync(int craftTypeId, bool isActive)
+        {
+            return _repository.ToggleCraftTypeAsync(craftTypeId, isActive);
         }
 
         public Task<List<CraftLocation>> GetLocationsAsync()

--- a/smelite_app/smelite_app/Services/ICraftService.cs
+++ b/smelite_app/smelite_app/Services/ICraftService.cs
@@ -10,9 +10,12 @@ namespace smelite_app.Services
         Task<IEnumerable<Craft>> GetFilteredCraftsAsync(int? craftTypeId, int? locationId, string? searchName);
         Task<Craft?> GetCraftByIdAsync(int id);
         Task<List<CraftType>> GetCraftTypesAsync();
+        Task<List<CraftType>> GetAllCraftTypesAsync();
         Task<CraftType?> GetCraftTypeByIdAsync(int id);
+        Task<CraftType?> GetCraftTypeByIdAllAsync(int id);
         Task AddCraftTypeAsync(CraftType craftType);
         Task UpdateCraftTypeAsync(CraftType craftType);
+        Task ToggleCraftTypeAsync(int craftTypeId, bool isActive);
         Task<List<CraftLocation>> GetLocationsAsync();
         Task<List<CraftPackage>> GetPackagesAsync();
 

--- a/smelite_app/smelite_app/ViewModels/CraftType/CraftTypeListItemViewModel.cs
+++ b/smelite_app/smelite_app/ViewModels/CraftType/CraftTypeListItemViewModel.cs
@@ -4,5 +4,6 @@ namespace smelite_app.ViewModels.CraftType
     {
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
+        public bool IsActive { get; set; }
     }
 }

--- a/smelite_app/smelite_app/Views/CraftTypeAdmin/Index.cshtml
+++ b/smelite_app/smelite_app/Views/CraftTypeAdmin/Index.cshtml
@@ -8,6 +8,7 @@
     <thead>
         <tr>
             <th>Name</th>
+            <th>Status</th>
             <th></th>
         </tr>
     </thead>
@@ -16,8 +17,16 @@
     {
         <tr>
             <td>@item.Name</td>
+            <td>@(item.IsActive ? "Active" : "Inactive")</td>
             <td>
-                <a asp-action="Edit" asp-route-id="@item.Id" class="btn-main-outline btn-xs">Edit</a> |
+                <form asp-action="Toggle" method="post" style="display:inline">
+                    <input type="hidden" name="id" value="@item.Id" />
+                    <input type="hidden" name="active" value="@(item.IsActive ? false : true)" />
+                    <button type="submit" class="btn-main-outline btn-xs">@(item.IsActive ? "Deactivate" : "Activate")</button>
+                </form>
+                |
+                <a asp-action="Edit" asp-route-id="@item.Id" class="btn-main-outline btn-xs">Edit</a>
+                |
                 <a asp-action="Delete" asp-route-id="@item.Id" class="btn-main-outline btn-xs">Delete</a>
             </td>
         </tr>


### PR DESCRIPTION
## Summary
- allow editing CraftType entries regardless of IsDeleted status
- show CraftType activation state in admin view
- add toggle action to activate or deactivate craft types
- expose new repository and service APIs for CraftType activation
- test CraftService and integration behavior for craft type toggling

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878c69d8388330ae07d1123021fbcb