### PR TITLE
Fix layout script loading and login markup, add font-face and fix logo path

### DIFF
--- a/smelite_app/smelite_app/Views/Home/Index.cshtml
+++ b/smelite_app/smelite_app/Views/Home/Index.cshtml
@@ -104,7 +104,7 @@
     <div class="bg-img newsletter-bg-img"></div>
     <div class="newsletter-inner">
         <div class="newsletter-logo">
-            <img src="~/images/smelitelogo-02.svg" alt="smelite.bg logo" />
+            <img src="~/MainPage/smelitelogo-02.svg" alt="smelite.bg logo" />
         </div>
         <form asp-action="Subscribe" method="post" class="newsletter-form" autocomplete="off">
             <h2>Абонирай се за блога</h2>

--- a/smelite_app/smelite_app/Views/Shared/_Layout.cshtml
+++ b/smelite_app/smelite_app/Views/Shared/_Layout.cshtml
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="~/css/styles.css" />
     @* <link rel="stylesheet" href="~/css/site.css" /> *@
     @* <script src="~/js/site.js" asp-append-version="true"></script> *@
-    <script src="~/js/script.js" asp-append-version="true"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Pacifico|Montserrat:400,700|Amatic+SC&display=swap" rel="stylesheet">
     <!-- AOS CSS -->
@@ -30,7 +29,7 @@
             <a asp-controller="Home" asp-action="HowItWorks">Как работи</a>
             <a asp-controller="Blog" asp-action="Index">Блог</a>
             <a asp-controller="Home" asp-action="Contact">Контакт</a>
-            <a href="#" class="header-login-btn">@await Html.PartialAsync("_LoginPartial")</a>
+            @await Html.PartialAsync("_LoginPartial")
         </nav>
         <button class="burger-btn" id="burger-btn" aria-label="Меню">
             <span></span><span></span><span></span>
@@ -66,7 +65,7 @@
     </footer>
 
 
-    @* <script src="~/js/script.js"></script> *@
+    <script src="~/js/script.js" asp-append-version="true"></script>
     <script src="~/js/site.js"></script>
     @RenderSection("Scripts", required: false)
 

--- a/smelite_app/smelite_app/Views/Shared/_LoginPartial.cshtml
+++ b/smelite_app/smelite_app/Views/Shared/_LoginPartial.cshtml
@@ -3,42 +3,38 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
 
-<ul class="nav login-nav" style="margin-left:16px;">
+<div class="login-nav" style="margin-left:16px;">
     @if (SignInManager.IsSignedIn(User))
     {
         var user = await UserManager.GetUserAsync(User);
         var roles = await UserManager.GetRolesAsync(user);
         var role = roles.FirstOrDefault();
 
-        <li class="nav-item user-welcome">
-            @if (User.IsInRole("Apprentice"))
-            {
-                <a asp-area="" asp-controller="Apprentice" asp-action="Profile" title="Manage" class="user-name-link">
-                    Здравей, @user.FirstName - @role!
-                </a>
-            }
-            @if (User.IsInRole("Master"))
-            {
-                <a asp-area="" asp-controller="Master" asp-action="Profile" title="Manage" class="user-name-link">
-                    Здравей, @user.FirstName - @role!
-                </a>
-            }
-            @if (User.IsInRole("Admin"))
-            {
-                <a asp-area="" asp-controller="Admin" asp-action="Profile" title="Manage" class="user-name-link">
-                    Здравей, @user.FirstName - @role!
-                </a>
-            }
-            <form asp-area="" asp-controller="Account" asp-action="Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })" method="post" style="display:inline;">
-                <button type="submit" class="btn-main-outline btn-xs logout-btn" style="margin-left:8px;">Изход</button>
-            </form>
-        </li>
+        @if (User.IsInRole("Apprentice"))
+        {
+            <a asp-area="" asp-controller="Apprentice" asp-action="Profile" title="Manage" class="user-name-link">
+                Здравей, @user.FirstName - @role!
+            </a>
+        }
+        @if (User.IsInRole("Master"))
+        {
+            <a asp-area="" asp-controller="Master" asp-action="Profile" title="Manage" class="user-name-link">
+                Здравей, @user.FirstName - @role!
+            </a>
+        }
+        @if (User.IsInRole("Admin"))
+        {
+            <a asp-area="" asp-controller="Admin" asp-action="Profile" title="Manage" class="user-name-link">
+                Здравей, @user.FirstName - @role!
+            </a>
+        }
+        <form asp-area="" asp-controller="Account" asp-action="Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })" method="post" style="display:inline;">
+            <button type="submit" class="btn-main-outline btn-xs logout-btn" style="margin-left:8px;">Изход</button>
+        </form>
     }
     else
     {
-        <li class="nav-item">
-            <a asp-area="" asp-controller="Account" asp-action="Login" class="btn-main">Вход</a>
-        </li>
+        <a class="header-login-btn" asp-area="" asp-controller="Account" asp-action="Login">Вход</a>
     }
-</ul>
+</div>
 

--- a/smelite_app/smelite_app/wwwroot/css/styles.css
+++ b/smelite_app/smelite_app/wwwroot/css/styles.css
@@ -1,3 +1,10 @@
+@font-face {
+    font-family: 'GlyphWorld Mountain';
+    src: url('/MainPage/GlyphWorld-Mountain.otf') format('opentype');
+    font-weight: normal;
+    font-style: normal;
+}
+
 :root {
     /* Бранд палитра */
     --bg-main: #f6efe3;


### PR DESCRIPTION
## Summary
- Load main script after page body to avoid premature DOM access
- Simplify login partial and align login button with design
- Include GlyphWorld Mountain font and fix newsletter logo path

## Testing
- `dotnet test smelite_app/smelite_app.sln` *(fails: command not found: dotnet)*
- `wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb` *(fails: Proxy tunneling failed: ForbiddenUnable to establish SSL connection)*

------
https://chatgpt.com/codex/tasks/task_e_688e81a43a788330a90f19dd1105656e