### PR TITLE
Fix infinite scroll gaps and preload image dimensions

### DIFF
--- a/smelite_app/smelite_app/Views/Home/Index.cshtml
+++ b/smelite_app/smelite_app/Views/Home/Index.cshtml
@@ -26,22 +26,22 @@
     <div class="bg-img crafts-bg-img"></div>
     <div class="infinite-scroll infinite-crafts-scroll" id="infinite-crafts-scroll">
         <a href="/Crafts" class="craft-card" tabindex="0">
-            <img class="craft-img" src="~/Defaults/grn.png" alt="Грънчарство">
+            <img class="craft-img" src="~/Defaults/grn.png" alt="Грънчарство" width="78" height="78" loading="lazy">
             <div class="craft-name">Грънчарство</div>
             <div class="craft-desc">Уроци и работилници</div>
         </a>
         <a href="/Crafts" class="craft-card" tabindex="0">
-            <img class="craft-img" src="~/Defaults/dvrb.png" alt="Дърворезба">
+            <img class="craft-img" src="~/Defaults/dvrb.png" alt="Дърворезба" width="78" height="78" loading="lazy">
             <div class="craft-name">Дърворезба</div>
             <div class="craft-desc">Традиционна резба</div>
         </a>
         <a href="/Crafts" class="craft-card" tabindex="0">
-            <img class="craft-img" src="~/Defaults/tkch.png" alt="Тъкачество">
+            <img class="craft-img" src="~/Defaults/tkch.png" alt="Тъкачество" width="78" height="78" loading="lazy">
             <div class="craft-name">Тъкачество</div>
             <div class="craft-desc">Тъкане с майсторка</div>
         </a>
         <a href="/Crafts" class="craft-card" tabindex="0">
-            <img class="craft-img" src="~/Defaults/kzh.png" alt="Кожухарство">
+            <img class="craft-img" src="~/Defaults/kzh.png" alt="Кожухарство" width="78" height="78" loading="lazy">
             <div class="craft-name">Кожухарство</div>
             <div class="craft-desc">Изделия от кожа</div>
         </a>
@@ -76,17 +76,17 @@
     <div class="sponsors-content">
         <div class="infinite-scroll infinite-sponsors-scroll" id="infinite-sponsors-scroll">
             <a href="https://www.kaolin.bg/" class="sponsor-card" tabindex="0" target="_blank" rel="noopener">
-                <img class="sponsor-img" src="https://yourcdn.com/kaolin-logo.png" alt="Kaolin">
+                <img class="sponsor-img" src="https://yourcdn.com/kaolin-logo.png" alt="Kaolin" width="78" height="78" loading="lazy">
                 <div class="sponsor-name">Каолин</div>
                 <div class="sponsor-desc">Традиции в минералите</div>
             </a>
             <a href="https://www.fibank.bg/" class="sponsor-card" tabindex="0" target="_blank" rel="noopener">
-                <img class="sponsor-img" src="https://yourcdn.com/fibank-logo.png" alt="Fibank">
+                <img class="sponsor-img" src="https://yourcdn.com/fibank-logo.png" alt="Fibank" width="78" height="78" loading="lazy">
                 <div class="sponsor-name">Fibank</div>
                 <div class="sponsor-desc">Твоята банка</div>
             </a>
             <a href="https://www.dev.bg/" class="sponsor-card" tabindex="0" target="_blank" rel="noopener">
-                <img class="sponsor-img" src="https://yourcdn.com/devbg-logo.png" alt="DEV.BG">
+                <img class="sponsor-img" src="https://yourcdn.com/devbg-logo.png" alt="DEV.BG" width="78" height="78" loading="lazy">
                 <div class="sponsor-name">DEV.BG</div>
                 <div class="sponsor-desc">IT общността на България</div>
             </a>

--- a/smelite_app/smelite_app/wwwroot/css/site.css
+++ b/smelite_app/smelite_app/wwwroot/css/site.css
@@ -200,12 +200,14 @@ header {
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;
     align-items: stretch;
+    scroll-padding-left: 16px;
+    scroll-padding-right: 16px;
 }
 
     .crafts-list-scroll::before,
     .crafts-list-scroll::after {
         content: '';
-        flex: 1 1 0;
+        flex: 0 0 16px;
     }
 
 .craft-card {
@@ -279,12 +281,14 @@ header {
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;
     align-items: stretch;
+    scroll-padding-left: 16px;
+    scroll-padding-right: 16px;
 }
 
     .sponsors-list-scroll::before,
     .sponsors-list-scroll::after {
         content: '';
-        flex: 1 1 0;
+        flex: 0 0 16px;
     }
 
 .sponsor-card {

--- a/smelite_app/smelite_app/wwwroot/js/script.js
+++ b/smelite_app/smelite_app/wwwroot/js/script.js
@@ -49,9 +49,13 @@ function makeInfiniteScroll(selector, cardSelector, rowClass) {
     const cards = Array.from(scroll.querySelectorAll(cardSelector));
     const row = document.createElement('div');
     row.className = rowClass;
-    cards.concat(cards).forEach(c => row.appendChild(c.cloneNode(true)));
-    scroll.querySelectorAll(cardSelector).forEach(c => c.remove());
     scroll.appendChild(row);
+
+    while (row.scrollWidth < scroll.clientWidth * 2) {
+        cards.forEach(c => row.appendChild(c.cloneNode(true)));
+    }
+
+    cards.forEach(c => c.remove());
 
     // Pause loop on hover
     scroll.addEventListener('mouseenter', () => scroll.classList.add('paused'));
@@ -86,8 +90,11 @@ function makeInfiniteScroll(selector, cardSelector, rowClass) {
     });
     document.addEventListener('touchend', () => { dragging = false; });
 }
-makeInfiniteScroll('infinite-crafts-scroll', '.craft-card', 'infinite-crafts-row');
-makeInfiniteScroll('infinite-sponsors-scroll', '.sponsor-card', 'infinite-sponsors-row');
+
+window.addEventListener('load', () => {
+    makeInfiniteScroll('infinite-crafts-scroll', '.craft-card', 'infinite-crafts-row');
+    makeInfiniteScroll('infinite-sponsors-scroll', '.sponsor-card', 'infinite-sponsors-row');
+});
 
 // --------- Reveal ефекти (обща логика за всички reveal секции) ---------
 document.querySelectorAll('.reveal-section').forEach(section => {


### PR DESCRIPTION
## Summary
- Extend infinite scroll rows until twice the container width and run setup after window load
- Remove flex-filling pseudo-elements and add scroll padding to craft and sponsor lists
- Define fixed sizes for craft and sponsor images to prevent layout shift

## Testing
- `dotnet test smelite_app/smelite_app.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f983f7dd0833084b7e2f146dc7a2f