### PR TITLE
Align secondary pages with home design

### DIFF
--- a/smelite_app/smelite_app/wwwroot/css/styles.css
+++ b/smelite_app/smelite_app/wwwroot/css/styles.css
@@ -930,26 +930,27 @@ body.menu-open { overflow: hidden; }
     justify-content: center;
     gap: 8px;
     width: 100%;
-    background: #fff;
+    background: var(--white);
     border-radius: 18px 18px 0 0;
     box-shadow: 0 1px 10px #0001;
     padding: 14px 18px 8px 18px;
     margin: 0;
     box-sizing: border-box;
+    animation: fadeInUp 0.6s ease both;
 }
 
 .filter-input, .filter-select {
-    border: 1.5px solid #e3d5c1;
+    border: 1.5px solid var(--earth-beige);
     border-radius: 8px;
     padding: 7px 10px;
     font-size: 0.97rem;
-    background: #fff;
+    background: var(--white);
     outline: none;
     transition: border 0.18s, box-shadow 0.18s;
     font-family: 'Montserrat', sans-serif;
     min-width: 80px;
     max-width: 180px;
-    color: var(--brown-dark, #422D15);
+    color: var(--earth-brown);
     height: 36px;
     box-sizing: border-box;
 }
@@ -975,7 +976,7 @@ body.menu-open { overflow: hidden; }
 }
 
 .filter-input:focus, .filter-select:focus {
-    border: 1.5px solid var(--yellow, #c9a04a);
+    border: 1.5px solid var(--earth-yellow);
     box-shadow: 0 1px 6px #f3e0cc;
 }
 
@@ -1079,6 +1080,16 @@ body.menu-open { overflow: hidden; }
     .craft-table-img {
         width: 38px;
         height: 38px;
+    }
+}
+
+@media (max-width: 600px) {
+    .crafts-filter-form {
+        padding: 10px 4vw 8px 4vw;
+    }
+
+    .filter-input, .filter-select, .filter-btn {
+        font-size: 1rem;
     }
 }
 
@@ -1191,12 +1202,13 @@ body.menu-open { overflow: hidden; }
 }
 
 .craft-title {
-    font-family: 'Montserrat', sans-serif;
+    font-family: 'Caveat', cursive;
     font-size: 2.2rem;
     font-weight: 700;
-    color: var(--brown-dark, #422D15);
+    color: var(--earth-brown);
     margin-bottom: 8px;
     letter-spacing: 1px;
+    text-align: center;
 }
 
 .craft-type-row {
@@ -1512,8 +1524,8 @@ body.menu-open { overflow: hidden; }
 }
 
 .mission-card {
-    background: #fff;
-    box-shadow: 0 3px 24px #e3d5c1aa;
+    background: var(--white);
+    box-shadow: 0 3px 24px rgba(236,220,190,0.66);
     border-radius: 22px;
     padding: 28px 34px;
     display: flex;
@@ -1521,6 +1533,7 @@ body.menu-open { overflow: hidden; }
     align-items: flex-start;
     margin-top: 26px;
     flex-wrap: wrap;
+    animation: fadeInUp 0.6s ease both;
 }
 
 .mission-img-wrap {
@@ -1546,10 +1559,10 @@ body.menu-open { overflow: hidden; }
 }
 
 .mission-section-title {
-    font-family: 'Montserrat', sans-serif;
-    font-size: 1.18rem;
+    font-family: 'Caveat', cursive;
+    font-size: 1.4rem;
     font-weight: 700;
-    color: var(--brown-dark, #422D15);
+    color: var(--earth-brown);
     margin: 0 0 6px 0;
     letter-spacing: 0.5px;
 }
@@ -1557,8 +1570,8 @@ body.menu-open { overflow: hidden; }
 .mission-list {
     margin: 0 0 0 16px;
     padding: 0;
-    color: #6d5743;
-    font-size: 1.04rem;
+    color: var(--earth-brown);
+    font-size: 1.1rem;
 }
 
 @media (max-width: 900px) {
@@ -1572,6 +1585,21 @@ body.menu-open { overflow: hidden; }
     .mission-img {
         max-width: 88vw;
         margin-bottom: 8px;
+    }
+}
+
+@media (max-width: 600px) {
+    .mission-card {
+        padding: 12px 4vw;
+        gap: 14px;
+    }
+
+    .mission-section-title {
+        font-size: 1.2rem;
+    }
+
+    .mission-list {
+        font-size: 1rem;
     }
 }
 
@@ -2279,6 +2307,18 @@ select.filter-input {
         opacity: 1;
         transform: translateY(0);
     }
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
 
 /* Пулсиращ бутон */
 .pulse-btn {


### PR DESCRIPTION
## Summary
- Style craft filters with brand colors and fade-in animation
- Switch page headings to Caveat font and center them for consistency
- Harmonize mission section colors, add fade-in animation and mobile tweaks
- Add reusable fadeInUp keyframes and mobile media queries

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894a620730c8330b1576de0165d2ec9