### PR TITLE
Send subscription confirmation emails and centralize messages

### DIFF
--- a/smelite_app/smelite_app.Tests/IntegrationTests/ApprenticeControllerTests.cs
+++ b/smelite_app/smelite_app.Tests/IntegrationTests/ApprenticeControllerTests.cs
@@ -7,6 +7,7 @@ using smelite_app.Controllers;
 using smelite_app.Models;
 using smelite_app.Repositories;
 using smelite_app.Services;
+using smelite_app.Helpers;
 using Xunit;
 
 namespace smelite_app.Tests.IntegrationTests
@@ -27,7 +28,7 @@ namespace smelite_app.Tests.IntegrationTests
 
             var appRepo = new ApprenticeRepository(context);
             var craftRepo = new CraftRepository(context);
-            var service = new ApprenticeService(appRepo, craftRepo, new EmailSender());
+            var service = new ApprenticeService(appRepo, craftRepo, new Mock<IEmailSender>().Object);
             var paySvc = new Mock<IPaymentService>();
             paySvc.Setup(p => p.CreateCheckoutSessionAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("http://stripe");
 
@@ -57,7 +58,7 @@ namespace smelite_app.Tests.IntegrationTests
             var userMgr = TestHelper.GetMockUserManager(user);
             var appRepo = new ApprenticeRepository(context);
             var craftRepo = new CraftRepository(context);
-            var service = new ApprenticeService(appRepo, craftRepo, new EmailSender());
+            var service = new ApprenticeService(appRepo, craftRepo, new Mock<IEmailSender>().Object);
             var env = new Mock<IWebHostEnvironment>();
             var paySvc = new Mock<IPaymentService>();
             paySvc.Setup(p => p.CreateCheckoutSessionAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("http://stripe");

--- a/smelite_app/smelite_app.Tests/UnitTests/AccountServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/AccountServiceTests.cs
@@ -24,14 +24,14 @@ namespace smelite_app.Tests.UnitTests
             var logger = new Mock<ILogger<AccountService>>();
             var urlHelperFactory = new Mock<IUrlHelperFactory>();
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
-            var emailSender = new EmailSender();
+            var emailSender = new Mock<IEmailSender>();
             return new AccountService(accountRepo.Object,
                                      masterRepo.Object,
                                      apprenticeRepo.Object,
                                      logger.Object,
                                      urlHelperFactory.Object,
                                      httpContextAccessor.Object,
-                                     emailSender);
+                                     emailSender.Object);
         }
 
         [Fact]

--- a/smelite_app/smelite_app.Tests/UnitTests/EmailSubscriptionServiceTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/EmailSubscriptionServiceTests.cs
@@ -1,0 +1,26 @@
+using Moq;
+using smelite_app.Models;
+using smelite_app.Repositories;
+using smelite_app.Services;
+using smelite_app.Helpers;
+using Xunit;
+
+namespace smelite_app.Tests.UnitTests
+{
+    public class EmailSubscriptionServiceTests
+    {
+        [Fact]
+        public async Task Subscribe_NewEmail_AddsAndSends()
+        {
+            var repo = new Mock<IEmailSubscriptionRepository>();
+            repo.Setup(r => r.GetByEmailAsync("t@test.com")).ReturnsAsync((EmailSubscription?)null);
+            var emailSender = new Mock<IEmailSender>();
+            var service = new EmailSubscriptionService(repo.Object, emailSender.Object);
+
+            await service.SubscribeAsync("t@test.com");
+
+            repo.Verify(r => r.AddAsync(It.Is<EmailSubscription>(s => s.Email == "t@test.com")), Times.Once);
+            emailSender.Verify(s => s.SendEmailAsync("t@test.com", EmailMessages.SubscriptionConfirmSubject, EmailMessages.SubscriptionConfirmBody), Times.Once);
+        }
+    }
+}

--- a/smelite_app/smelite_app.Tests/UnitTests/HomeControllerTests.cs
+++ b/smelite_app/smelite_app.Tests/UnitTests/HomeControllerTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging;
+using Moq;
+using smelite_app.Controllers;
+using smelite_app.Services;
+using Xunit;
+
+namespace smelite_app.Tests.UnitTests
+{
+    public class HomeControllerTests
+    {
+        [Fact]
+        public async Task Subscribe_InvalidEmail_RedirectsWithError()
+        {
+            var service = new Mock<IEmailSubscriptionService>();
+            var logger = new Mock<ILogger<HomeController>>();
+            var controller = new HomeController(logger.Object, service.Object);
+            controller.TempData = new TempDataDictionary(new DefaultHttpContext(), Mock.Of<ITempDataProvider>());
+
+            var result = await controller.Subscribe("");
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Невалиден имейл", controller.TempData["Notification"]);
+            service.Verify(s => s.SubscribeAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Subscribe_ValidEmail_CallsServiceAndRedirects()
+        {
+            var service = new Mock<IEmailSubscriptionService>();
+            var logger = new Mock<ILogger<HomeController>>();
+            var controller = new HomeController(logger.Object, service.Object);
+            controller.TempData = new TempDataDictionary(new DefaultHttpContext(), Mock.Of<ITempDataProvider>());
+
+            var result = await controller.Subscribe("a@test.com");
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Благодарим за абонамента", controller.TempData["Notification"]);
+            service.Verify(s => s.SubscribeAsync("a@test.com"), Times.Once);
+        }
+    }
+}

--- a/smelite_app/smelite_app/Helpers/EmailMessages.cs
+++ b/smelite_app/smelite_app/Helpers/EmailMessages.cs
@@ -1,0 +1,28 @@
+namespace smelite_app.Helpers
+{
+    public static class EmailMessages
+    {
+        public static string SubscriptionConfirmSubject = "Успешен абонамент";
+        public static string SubscriptionConfirmBody = "Благодарим, че се абонирахте за нашия бюлетин.";
+
+        public static string PaymentUpdatedSubject = "Payment updated";
+        public static string PaymentUpdatedBody = "Payment {0} status changed to {1}.";
+
+        public static string ApprenticeshipRequestedSubject = "Apprenticeship requested";
+        public static string ApprenticeshipRequestedBody = "Apprentice {0} requested offering {1}.";
+
+        public static string CraftCreatedSubject = "Craft created";
+        public static string CraftCreatedBody = "Master {0} created craft '{1}'.";
+
+        public static string NewAccountCreatedSubject = "New account created";
+        public static string NewAccountCreatedBody = "User {0} registered as {1}.";
+
+        public static string AccountVerifiedSubject = "Account verified";
+        public static string AccountVerifiedBody = "User {0} has verified their account.";
+
+        public static string ConfirmEmailSubject = "Confirm your email";
+        public static string ConfirmEmailBody = "Please confirm your account by <a href='{0}'>clicking here</a>.";
+
+        public static string BlogPostBody = "{0}<br/><a href='{1}'>Прочети повече</a>";
+    }
+}

--- a/smelite_app/smelite_app/Helpers/EmailSender.cs
+++ b/smelite_app/smelite_app/Helpers/EmailSender.cs
@@ -3,7 +3,7 @@ using System.Net;
 
 namespace smelite_app.Helpers
 {
-    public class EmailSender
+    public class EmailSender : IEmailSender
     {
         private readonly string _smtpHost = "smtp.gmail.com";
         private readonly int _smtpPort = 587;

--- a/smelite_app/smelite_app/Helpers/IEmailSender.cs
+++ b/smelite_app/smelite_app/Helpers/IEmailSender.cs
@@ -1,0 +1,7 @@
+namespace smelite_app.Helpers
+{
+    public interface IEmailSender
+    {
+        Task<bool> SendEmailAsync(string toEmail, string subject, string body);
+    }
+}

--- a/smelite_app/smelite_app/Program.cs
+++ b/smelite_app/smelite_app/Program.cs
@@ -72,7 +72,7 @@ namespace smelite_app
             builder.Services.AddScoped<Services.IMasterService, Services.MasterService>();
             builder.Services.AddScoped<Services.IAccountService, Services.AccountService>();
             builder.Services.AddScoped<Services.IAdminService, Services.AdminService>();
-            builder.Services.AddTransient<Helpers.EmailSender>();
+            builder.Services.AddTransient<Helpers.IEmailSender, Helpers.EmailSender>();
             builder.Services.AddScoped<LogActionFilter>();
             builder.Services.AddScoped<Services.IPaymentService, Services.PaymentService>();
             builder.Services.AddScoped<Services.IBlogService, Services.BlogService>();

--- a/smelite_app/smelite_app/Services/AccountService.cs
+++ b/smelite_app/smelite_app/Services/AccountService.cs
@@ -21,7 +21,7 @@ namespace smelite_app.Services
         private readonly ILogger<AccountService> _logger;
         private readonly IUrlHelperFactory _urlHelperFactory;
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly EmailSender _emailSender;
+        private readonly IEmailSender _emailSender;
 
         public AccountService(
             IAccountRepository accountRepo,
@@ -30,7 +30,7 @@ namespace smelite_app.Services
             ILogger<AccountService> logger,
             IUrlHelperFactory urlHelperFactory,
             IHttpContextAccessor httpContextAccessor,
-            EmailSender emailSender)
+            IEmailSender emailSender)
         {
             _accountRepo = accountRepo;
             _masterRepo = masterRepo;
@@ -133,10 +133,10 @@ namespace smelite_app.Services
                 var urlHelper = _urlHelperFactory.GetUrlHelper(new ActionContext(httpContext, httpContext.GetRouteData(), new ActionDescriptor()));
                 var link = urlHelper.Action("ConfirmEmail", "Account", new { userId = user.Id, code = token }, httpContext.Request.Scheme);
 
-                await _emailSender.SendEmailAsync(user.Email!, "Confirm your email", $"Please confirm your account by <a href='{link}'>clicking here</a>.");
+                await _emailSender.SendEmailAsync(user.Email!, EmailMessages.ConfirmEmailSubject, string.Format(EmailMessages.ConfirmEmailBody, link));
                 await _emailSender.SendEmailAsync(Variables.defaultEmail,
-                    "New account created",
-                    $"User {user.Email} registered as {user.Role}.");
+                    EmailMessages.NewAccountCreatedSubject,
+                    string.Format(EmailMessages.NewAccountCreatedBody, user.Email, user.Role));
 
                 _logger.LogInformation("Successful registration for {Email}", model.Email);
             }
@@ -165,8 +165,8 @@ namespace smelite_app.Services
             {
                 _logger.LogInformation("Email confirmed for {Email}", user.Email);
                 await _emailSender.SendEmailAsync(Variables.defaultEmail,
-                    "Account verified",
-                    $"User {user.Email} has verified their account.");
+                    EmailMessages.AccountVerifiedSubject,
+                    string.Format(EmailMessages.AccountVerifiedBody, user.Email));
             }
             else
                 foreach (var error in result.Errors)

--- a/smelite_app/smelite_app/Services/AdminService.cs
+++ b/smelite_app/smelite_app/Services/AdminService.cs
@@ -9,8 +9,8 @@ namespace smelite_app.Services
     public class AdminService : IAdminService
     {
         private readonly ApplicationDbContext _context;
-        private readonly EmailSender _emailSender;
-        public AdminService(ApplicationDbContext context, EmailSender emailSender)
+        private readonly IEmailSender _emailSender;
+        public AdminService(ApplicationDbContext context, IEmailSender emailSender)
         {
             _context = context;
             _emailSender = emailSender ?? throw new ArgumentNullException(nameof(emailSender));
@@ -80,8 +80,8 @@ namespace smelite_app.Services
             }
             await _context.SaveChangesAsync();
             await _emailSender.SendEmailAsync(Variables.defaultEmail,
-                "Payment updated",
-                $"Payment {payment.Id} status changed to {status}.");
+                EmailMessages.PaymentUpdatedSubject,
+                string.Format(EmailMessages.PaymentUpdatedBody, payment.Id, status));
         }
 
         public Task<List<Payment>> GetPaymentsAsync()

--- a/smelite_app/smelite_app/Services/ApprenticeService.cs
+++ b/smelite_app/smelite_app/Services/ApprenticeService.cs
@@ -11,9 +11,9 @@ namespace smelite_app.Services
     {
         private readonly IApprenticeRepository _apprenticeRepository;
         private readonly ICraftRepository _craftRepository;
-        private readonly EmailSender _emailSender;
+        private readonly IEmailSender _emailSender;
 
-        public ApprenticeService(IApprenticeRepository apprenticeRepository, ICraftRepository craftRepository, EmailSender emailSender)
+        public ApprenticeService(IApprenticeRepository apprenticeRepository, ICraftRepository craftRepository, IEmailSender emailSender)
         {
             _apprenticeRepository = apprenticeRepository ?? throw new ArgumentNullException(nameof(apprenticeRepository));
             _craftRepository = craftRepository ?? throw new ArgumentNullException(nameof(craftRepository));
@@ -76,8 +76,8 @@ namespace smelite_app.Services
 
             await _apprenticeRepository.AddApprenticeshipAsync(apprenticeship);
             await _emailSender.SendEmailAsync(Variables.defaultEmail,
-                "Apprenticeship requested",
-                $"Apprentice {apprenticeProfileId} requested offering {craftOfferingId}.");
+                EmailMessages.ApprenticeshipRequestedSubject,
+                string.Format(EmailMessages.ApprenticeshipRequestedBody, apprenticeProfileId, craftOfferingId));
 
             return apprenticeship.Payment;
         }

--- a/smelite_app/smelite_app/Services/BlogService.cs
+++ b/smelite_app/smelite_app/Services/BlogService.cs
@@ -8,10 +8,10 @@ namespace smelite_app.Services
     public class BlogService : IBlogService
     {
         private readonly IBlogRepository _repo;
-        private readonly EmailSender _emailSender;
+        private readonly IEmailSender _emailSender;
         private readonly IEmailSubscriptionService _subscriptionService;
 
-        public BlogService(IBlogRepository repo, EmailSender emailSender, IEmailSubscriptionService subscriptionService)
+        public BlogService(IBlogRepository repo, IEmailSender emailSender, IEmailSubscriptionService subscriptionService)
         {
             _repo = repo;
             _emailSender = emailSender;
@@ -45,7 +45,7 @@ namespace smelite_app.Services
             foreach (var email in emails)
             {
                 var link = Variables.siteAddress + $"/Blog/Details/{post.Id}";
-                await _emailSender.SendEmailAsync(email, post.Title, $"{post.Content}<br/><a href='{link}'>Прочети повече</a>");
+                await _emailSender.SendEmailAsync(email, post.Title, string.Format(EmailMessages.BlogPostBody, post.Content, link));
             }
         }
 

--- a/smelite_app/smelite_app/Services/EmailSubscriptionService.cs
+++ b/smelite_app/smelite_app/Services/EmailSubscriptionService.cs
@@ -1,15 +1,18 @@
 using Microsoft.EntityFrameworkCore;
 using smelite_app.Models;
 using smelite_app.Repositories;
+using smelite_app.Helpers;
 
 namespace smelite_app.Services
 {
     public class EmailSubscriptionService : IEmailSubscriptionService
     {
         private readonly IEmailSubscriptionRepository _repo;
-        public EmailSubscriptionService(IEmailSubscriptionRepository repo)
+        private readonly IEmailSender _emailSender;
+        public EmailSubscriptionService(IEmailSubscriptionRepository repo, IEmailSender emailSender)
         {
             _repo = repo;
+            _emailSender = emailSender;
         }
 
         public Task<List<EmailSubscription>> GetAllAsync()
@@ -26,12 +29,14 @@ namespace smelite_app.Services
                 {
                     existing.IsActive = true;
                     await _repo.UpdateAsync(existing);
+                    await _emailSender.SendEmailAsync(email, EmailMessages.SubscriptionConfirmSubject, EmailMessages.SubscriptionConfirmBody);
                 }
                 return;
             }
 
             var subscription = new EmailSubscription { Email = email };
             await _repo.AddAsync(subscription);
+            await _emailSender.SendEmailAsync(email, EmailMessages.SubscriptionConfirmSubject, EmailMessages.SubscriptionConfirmBody);
         }
 
         public async Task ToggleActiveAsync(int id, bool isActive)

--- a/smelite_app/smelite_app/Services/MasterService.cs
+++ b/smelite_app/smelite_app/Services/MasterService.cs
@@ -11,9 +11,9 @@ namespace smelite_app.Services
     public class MasterService : IMasterService
     {
         private readonly IMasterRepository _masterRepository;
-        private readonly EmailSender _emailSender;
+        private readonly IEmailSender _emailSender;
 
-        public MasterService(IMasterRepository masterRepository, EmailSender emailSender)
+        public MasterService(IMasterRepository masterRepository, IEmailSender emailSender)
         {
             _masterRepository = masterRepository
                 ?? throw new ArgumentNullException(nameof(masterRepository));
@@ -86,8 +86,8 @@ namespace smelite_app.Services
 
             await _masterRepository.AddCraftAsync(masterProfileId, craft, offerings, images);
             await _emailSender.SendEmailAsync(Variables.defaultEmail,
-                "Craft created",
-                $"Master {masterProfileId} created craft '{craft.Name}'.");
+                EmailMessages.CraftCreatedSubject,
+                string.Format(EmailMessages.CraftCreatedBody, masterProfileId, craft.Name));
         }
 
         public Task<List<Craft>> GetCraftsAsync(int masterProfileId)


### PR DESCRIPTION
## Summary
- add `EmailMessages` helper with static email texts
- send confirmation email upon subscribing and refactor services to use centralized messages
- cover subscription flow and email sending with new unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(failed: repository not signed / package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689758fd17588330a33330d56a933e04