### PR TITLE
Validate email for homepage subscription

### DIFF
--- a/smelite_app/smelite_app/Controllers/HomeController.cs
+++ b/smelite_app/smelite_app/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using smelite_app.Models;
 using smelite_app.Services;
@@ -49,7 +50,9 @@ namespace smelite_app.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Subscribe(string email)
         {
-            if (string.IsNullOrWhiteSpace(email))
+            email = email?.Trim();
+            var validator = new EmailAddressAttribute();
+            if (string.IsNullOrWhiteSpace(email) || !validator.IsValid(email))
             {
                 TempData["Notification"] = "Невалиден имейл";
                 return RedirectToAction(nameof(Index));

--- a/smelite_app/smelite_app/Services/EmailSubscriptionService.cs
+++ b/smelite_app/smelite_app/Services/EmailSubscriptionService.cs
@@ -22,6 +22,7 @@ namespace smelite_app.Services
 
         public async Task SubscribeAsync(string email)
         {
+            email = email.Trim().ToLowerInvariant();
             var existing = await _repo.GetByEmailAsync(email);
             if (existing != null)
             {

--- a/smelite_app/smelite_app/Views/Home/Index.cshtml
+++ b/smelite_app/smelite_app/Views/Home/Index.cshtml
@@ -115,7 +115,6 @@
                 <input type="email" name="email" placeholder="Твоят имейл" required />
                 <button type="submit">Абонирай се</button>
             </div>
-            <div class="newsletter-success" style="display:none;">Благодарим за абонамента!</div>
         </form>
     </div>
 </section>

--- a/smelite_app/smelite_app/wwwroot/css/styles.css
+++ b/smelite_app/smelite_app/wwwroot/css/styles.css
@@ -684,12 +684,6 @@ body.menu-open { overflow: hidden; }
     color: #fff;
     transform: scale(1.06);
 }
-.newsletter-success {
-    color: var(--earth-green);
-    font-size: 0.98rem;
-    margin-top: 5px;
-    font-weight: normal;
-}
 @media (max-width: 900px) {
     .newsletter-inner { flex-direction: column; height: auto; padding: 18px 6px; }
     .newsletter-logo { justify-content: flex-start; margin-bottom: 16px; }

--- a/smelite_app/smelite_app/wwwroot/js/script.js
+++ b/smelite_app/smelite_app/wwwroot/js/script.js
@@ -155,16 +155,3 @@ if (header && hero) {
     window.addEventListener('resize', handleStickyHeader);
     window.addEventListener('DOMContentLoaded', handleStickyHeader);
 }
-
-
-// Newsletter subscribe demo (може да вържеш с бекенд, тук е само визуално)
-document.querySelectorAll('.newsletter-form').forEach(form => {
-    form.addEventListener('submit', function(e) {
-        e.preventDefault();
-        form.querySelector('.newsletter-success').style.display = "block";
-        setTimeout(() => {
-            form.querySelector('.newsletter-success').style.display = "none";
-            form.reset();
-        }, 4000);
-    });
-});


### PR DESCRIPTION
## Summary
- validate homepage subscription addresses with `EmailAddressAttribute`
- normalize subscription emails before storing
- allow homepage subscription form to post to `Subscribe` controller action

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689763af69108330b77871d3fc757cbc